### PR TITLE
Prevent leaking of handoff data after scheduler is initialised

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -258,12 +258,9 @@ fn kmain(handoff_data: HandoffWrapper) -> ! {
 	trace!("Handoff data:\n{handoff_data:x?}");
 
 	HalTy::early_init();
-	HalTy::breakpoint();
 
 	let usable_memory = handoff_data.memory.map.iter().filter(|entry|
-		entry.ty == MemoryType::Free
-			|| entry.ty == MemoryType::BootloaderCode
-			//|| entry.ty == MemoryType::BootloaderData
+		entry.ty == MemoryType::Free || entry.ty == MemoryType::BootloaderCode
 	);
 
 	// Split allocator system is used when a significant portion of memory is above the 4GiB boundary
@@ -281,8 +278,6 @@ fn kmain(handoff_data: HandoffWrapper) -> ! {
 	} else { false };
 
 	info!("Split allocator: {}", if split_allocators { "enabled" } else { "disabled" });
-
-	panicking::stack_trace();
 
 	{
 		use kernel_api::memory::PhysicalAddress;

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -10,7 +10,10 @@ use scheduler::Tid;
 
 pub mod scheduler;
 
-pub unsafe fn init(stack: &handoff::Stack, ttable: TTableTy) -> Tid {
+pub unsafe fn init(handoff_data: crate::HandoffWrapper) -> Tid {
+	let stack = handoff_data.memory.stack;
+	let ttable = handoff_data.to_empty_ttable();
+
 	// fixme: is highmem always correct?
 	let stack_phys_len = stack.top_virt - stack.bottom_virt - 1;
 	let stack_frames = OwnedFrames::from_raw_parts(


### PR DESCRIPTION
Page faults in the past have been caused by handoff data references leaking into other kernel threads, where they are invalid. This prevents construction of the scheduler until all references to handoff data are unborrowed.