### PR TITLE
Removed `pointer_is_aligned` feature

### DIFF
--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -1,7 +1,6 @@
 #![feature(ptr_metadata)]
 #![feature(try_blocks)]
 #![feature(let_chains)]
-#![feature(pointer_is_aligned)]
 #![feature(new_uninit)]
 #![feature(split_array)]
 #![feature(slice_ptr_len)]

--- a/elf/src/lib.rs
+++ b/elf/src/lib.rs
@@ -1,6 +1,4 @@
 #![no_std]
-#![feature(pointer_is_aligned)]
-#![feature(pointer_byte_offsets)]
 #![feature(never_type)]
 
 extern crate alloc;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -32,7 +32,6 @@
 #![feature(type_alias_impl_trait)]
 #![feature(asm_const)]
 #![feature(const_mut_refs)]
-#![feature(pointer_is_aligned)]
 #![feature(sync_unsafe_cell)]
 #![feature(arbitrary_self_types)]
 

--- a/mm/dmm/slab_allocator/src/lib.rs
+++ b/mm/dmm/slab_allocator/src/lib.rs
@@ -1,10 +1,9 @@
 #![cfg_attr(not(test), no_std)]
 #![feature(generic_const_exprs)]
 #![feature(slice_ptr_get)]
-#![feature(pointer_byte_offsets)]
 #![feature(strict_provenance)]
 #![feature(new_uninit)]
-#![feature(pointer_is_aligned)]
+#![feature(pointer_is_aligned_to)]
 
 extern crate alloc;
 
@@ -25,7 +24,7 @@ pub trait Cacheable: Default {
 
 pub struct SlabAllocator<'vmm, T: Cacheable> {
     virtual_allocator: &'vmm dyn VirtualMemoryAllocator,
-    slabs: linked_list::LinkedList<SlabMetadata>
+    slabs: linked_list::LinkedList<SlabMetadata>,
     _phantom: PhantomData<T>
 }
 

--- a/psf/src/lib.rs
+++ b/psf/src/lib.rs
@@ -1,6 +1,4 @@
-#![feature(pointer_byte_offsets)]
-#![feature(result_option_inspect)]
-#![feature(pointer_is_aligned)]
+#![feature(pointer_is_aligned_to)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use core::fmt;


### PR DESCRIPTION
Also account for `pointer_byte_offsets` being stabilized, and for the rename of `pointer_is_aligned_to`