### PR TITLE
Linker script improvements

### DIFF
--- a/kernel/src/hal/arch/amd64/linker.ld
+++ b/kernel/src/hal/arch/amd64/linker.ld
@@ -9,7 +9,7 @@ PHDRS {
     dynamic PT_DYNAMIC ;
     gnu_eh_frame 0x6474E550 FLAGS(0x4) ;
     lazy PT_LOAD FLAGS(0x20006) ;
-    tls PT_TLS FLAGS(0x6) ;
+    tls PT_TLS FLAGS(0x406) ;
 }
 
 SECTIONS {

--- a/kernel/src/hal/arch/amd64/linker.ld
+++ b/kernel/src/hal/arch/amd64/linker.ld
@@ -81,6 +81,10 @@ SECTIONS {
     {
         *(.eh_frame .eh_frame.*)
     } :rodata
+    .gcc_except_table :
+    {
+        *(.gcc_except_table .gcc_except_table.*)
+    } :rodata
 
 	. = ALIGN(4K);
     .text :

--- a/kernel/src/hal/arch/amd64/linker.ld
+++ b/kernel/src/hal/arch/amd64/linker.ld
@@ -138,7 +138,7 @@ SECTIONS {
 
 	. = ALIGN(4K);
 	PROVIDE(__popcorn_vmem_bootstrap_start = .);
-	. += 1M;
+	. += 8M;
 	PROVIDE(__popcorn_vmem_bootstrap_end = .);
 
 	/DISCARD/ : {


### PR DESCRIPTION
- Add TLS flag to TLS sections (closes #86)
- Merge all `.gcc_except_table` sections together
- Bump virtual memory bootstrap allocation region from 1M to 8M