### PR TITLE
Fix some missing traits for Mutex/RwLock/Syncify

### DIFF
--- a/kernel_api/src/sync/mod.rs
+++ b/kernel_api/src/sync/mod.rs
@@ -4,7 +4,7 @@
 
 #![stable(feature = "kernel_core_api", since = "0.1.0")]
 
-use core::ops::Deref;
+use core::ops::{Deref, DerefMut};
 #[cfg(not(feature = "use_std"))]
 #[stable(feature = "kernel_core_api", since = "0.1.0")]
 pub use mutex::{Mutex, MutexGuard, MutexGuardExt};
@@ -57,4 +57,13 @@ impl<T> Deref for Syncify<T> {
 }
 
 #[stable(feature = "kernel_core_api", since = "0.1.0")]
+impl<T> DerefMut for Syncify<T> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.0
+	}
+}
+
+#[stable(feature = "kernel_core_api", since = "0.1.0")]
 unsafe impl<T> Sync for Syncify<T> {}
+#[stable(feature = "kernel_core_api", since = "0.1.0")]
+unsafe impl<T> Send for Syncify<T> {}

--- a/kernel_api/src/sync/mutex.rs
+++ b/kernel_api/src/sync/mutex.rs
@@ -5,13 +5,13 @@ use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 
 /// A mutual exclusion primitive useful for protecting shared data
 #[stable(feature = "kernel_core_api", since = "0.1.0")]
-pub type Mutex<T> = lock_api::Mutex<RawSpinlock, T>;
+pub type Mutex<T: ?Sized> = lock_api::Mutex<RawSpinlock, T>;
 #[unstable(feature = "kernel_spinlocks", issue = "none")]
-pub type Spinlock<T> = lock_api::Mutex<RawSpinlock, T>;
+pub type Spinlock<T: ?Sized> = lock_api::Mutex<RawSpinlock, T>;
 
 /// An RAII implementation of a “scoped lock” of a mutex. When this structure is dropped (falls out of scope), the lock will be unlocked.
 #[stable(feature = "kernel_core_api", since = "0.1.0")]
-pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, RawSpinlock, T>;
+pub type MutexGuard<'a, T: ?Sized> = lock_api::MutexGuard<'a, RawSpinlock, T>;
 
 #[stable(feature = "kernel_core_api", since = "0.1.0")]
 pub trait MutexGuardExt {
@@ -76,6 +76,12 @@ pub struct RawSpinlock {
     state: AtomicU8,
     irq_state: AtomicUsize
 }
+
+#[stable(feature = "kernel_core_api", since = "0.1.0")]
+unsafe impl Send for RawSpinlock {}
+
+#[stable(feature = "kernel_core_api", since = "0.1.0")]
+unsafe impl Sync for RawSpinlock {}
 
 impl RawSpinlock {
     unsafe fn unlock_no_interrupts(&self) {

--- a/kernel_api/src/sync/rwlock.rs
+++ b/kernel_api/src/sync/rwlock.rs
@@ -4,19 +4,19 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// A reader-writer lock
 #[stable(feature = "kernel_core_api", since = "0.1.0")]
-pub type RwLock<T> = lock_api::RwLock<RwCount, T>;
+pub type RwLock<T: ?Sized> = lock_api::RwLock<RwCount, T>;
 
 /// RAII structure used to release the shared read access of a lock when dropped.
 #[stable(feature = "kernel_core_api", since = "0.1.0")]
-pub type RwReadGuard<'a, T> = lock_api::RwLockReadGuard<'a, RwCount, T>;
+pub type RwReadGuard<'a, T: ?Sized> = lock_api::RwLockReadGuard<'a, RwCount, T>;
 
 /// RAII structure used to release upgradable read access of a lock when dropped.
 #[stable(feature = "kernel_core_api", since = "0.1.0")]
-pub type RwUpgradableReadGuard<'a, T> = lock_api::RwLockUpgradableReadGuard<'a, RwCount, T>;
+pub type RwUpgradableReadGuard<'a, T: ?Sized> = lock_api::RwLockUpgradableReadGuard<'a, RwCount, T>;
 
 /// RAII structure used to release the exclusive write access of a lock when dropped.
 #[stable(feature = "kernel_core_api", since = "0.1.0")]
-pub type RwWriteGuard<'a, T> = lock_api::RwLockWriteGuard<'a, RwCount, T>;
+pub type RwWriteGuard<'a, T: ?Sized> = lock_api::RwLockWriteGuard<'a, RwCount, T>;
 
 #[doc(hidden)]
 #[stable(feature = "kernel_core_api", since = "0.1.0")]


### PR DESCRIPTION
- Allows using locks on unsized types
- Allows mutating objects behind Syncify