### PR TITLE
Allow resizing of the new mmap API

### DIFF
--- a/kernel/src/hal/acpi/mod.rs
+++ b/kernel/src/hal/acpi/mod.rs
@@ -131,7 +131,8 @@ impl AcpiHandlerExt for Handler<'_> {
 		let mapping = Mapping::new(config, <T as PagingReason>::reason()).expect("Unable to create physical mapping");
 
 
-		let (frames, pages) = mapping.into_raw_parts();
+		let (frames, pages) = mapping.into_raw_parts()
+				.expect("Initial `Mapping` allocation should be contiguous"); // FIXME: kernel_mmap discontinuous initial alloc
 		let (first_frame, phys_len, _) = frames.into_raw_parts();
 		let (first_page, virt_len, _) = pages.into_raw_parts();
 		assert_eq!(phys_len, virt_len);

--- a/kernel/src/hal/acpi/mod.rs
+++ b/kernel/src/hal/acpi/mod.rs
@@ -131,7 +131,7 @@ impl AcpiHandlerExt for Handler<'_> {
 		let mapping = Mapping::new(config, <T as PagingReason>::reason()).expect("Unable to create physical mapping");
 
 
-		let (frames, pages) = mapping.into_raw_parts()
+		let (frames, pages) = mapping.into_contiguous_raw_parts()
 				.expect("Initial `Mapping` allocation should be contiguous"); // FIXME: kernel_mmap discontinuous initial alloc
 		let (first_frame, phys_len, _) = frames.into_raw_parts();
 		let (first_page, virt_len, _) = pages.into_raw_parts();
@@ -217,7 +217,7 @@ impl AcpiHandler for Handler<'_> {
 		unsafe {
 			let frames = OwnedFrames::from_raw_parts(first_frame, len, region.handler().allocator);
 			let pages = OwnedPages::from_raw_parts(first_page, len, Global);
-			let _mapping = Mapping::from_raw_parts(frames, pages);
+			let _mapping = Mapping::from_contiguous_raw_parts(frames, pages);
 		}
 	}
 }

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -33,7 +33,7 @@ pub unsafe fn init(handoff_data: crate::HandoffWrapper) -> Tid {
 	let mut scheduler = scheduler::SCHEDULER.lock();
 	let tcb =  ThreadControlBlock {
 		name: Cow::Borrowed("init"),
-		kernel_stack: Stack::from_raw_parts(stack_frames, stack_pages),
+		kernel_stack: Stack::from_contiguous_raw_parts(stack_frames, stack_pages),
 		ttable,
 		state: ThreadState::Running,
 		save_state: Default::default(),

--- a/kernel_api/src/lib.rs
+++ b/kernel_api/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(new_uninit)]
 #![feature(doc_auto_cfg)]
 #![feature(doc_cfg_hide)]
+#![feature(let_chains)]
 #![cfg_attr(feature = "use_std", feature(lazy_cell))]
 #![warn(missing_docs)]
 

--- a/kernel_api/src/memory/mapping.rs
+++ b/kernel_api/src/memory/mapping.rs
@@ -415,9 +415,9 @@ pub(super) enum RawMappingContiguity {
 	Discontiguous,
 }
 
-/// Returned from [`RawMapping::into_raw_parts()`] if the underlying physical memory is not contiguous
+/// Returned from [`RawMapping::into_contiguous_raw_parts()`] if the underlying physical memory is not contiguous
 ///
-/// See the documentation for [`into_raw_parts()`](RawMapping::into_raw_parts()) for more information.
+/// See the documentation for [`into_contiguous_raw_parts()`](RawMapping::into_contiguous_raw_parts()) for more information.
 #[derive(Debug)]
 pub struct DiscontiguityError;
 
@@ -517,7 +517,7 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 	///
 	/// If the underlying physical memory is not contiguous, and so cannot be represented as a single instance
 	/// of [`OwnedFrames`], [`DiscontiguityError`] is returned.
-	pub fn into_raw_parts(mut self) -> Result<(OwnedFrames<'phys_alloc>, OwnedPages<A>), DiscontiguityError> {
+	pub fn into_contiguous_raw_parts(mut self) -> Result<(OwnedFrames<'phys_alloc>, OwnedPages<A>), DiscontiguityError> {
 		let frames = unsafe {
 			let RawMappingContiguity::Contiguous(base_frame) = self.contiguity else {
 				return Err(DiscontiguityError);
@@ -543,7 +543,7 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 		Ok((frames, pages))
 	}
 
-	pub unsafe fn from_raw_parts(frames: OwnedFrames<'phys_alloc>, pages: OwnedPages<A>) -> Self {
+	pub unsafe fn from_contiguous_raw_parts(frames: OwnedFrames<'phys_alloc>, pages: OwnedPages<A>) -> Self {
 		let (virtual_base, actual_vlen, virtual_allocator) = pages.into_raw_parts();
 		let (physical_base, physical_len, physical_allocator) = frames.into_raw_parts();
 		let correct_vlen = R::physical_length_to_virtual_length(physical_len);

--- a/kernel_api/src/memory/mapping.rs
+++ b/kernel_api/src/memory/mapping.rs
@@ -341,7 +341,7 @@ pub struct Config<'physical_allocator, A: VirtualAllocator> {
 
 impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 	/// Creates a new [mapping](self) configuration with default options
-	/// 
+	///
 	/// The default options are not guaranteed, but at the moment are:
 	/// - physical and virtual locations: anywhere
 	/// - lazily allocated
@@ -361,7 +361,7 @@ impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 	}
 
 	/// Set the physical allocator to use
-	/// 
+	///
 	/// This is used for both the underlying memory as well as any page tables that need creating
 	pub fn physical_allocator<'a>(self, allocator: &'a dyn BackingAllocator) -> Config<'a, A> {
 		Config {
@@ -396,7 +396,7 @@ impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 	}
 
 	/// Set the virtual location of the low address of the mapping
-	/// 
+	///
 	/// This is currently ignored
 	pub fn virtual_location(self, location: Location<Page>) -> Self {
 		Config {
@@ -406,36 +406,20 @@ impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 	}
 }
 
-// This exists to allow writing functions that only access the owned memory, rather than causing any allocations or deallocations,
-// to not have to be generic at runtime over the allocator and mapping controller
-pub(super) struct RawMappingInner<'phys_allocator> {
-	physical: OwnedFrames<'phys_allocator>,
-	virtual_valid_start: Page,
-}
+/// Used to track if the memory underlying the mapping is contiguous
+pub(super) enum RawMappingContiguity {
+	/// The underlying physical memory is contiguous, and starts at the contained frame
+	Contiguous(Frame),
 
-impl RawMappingInner<'_> {
-	pub(super) fn virtual_valid_start(&self) -> Page {
-		self.virtual_valid_start
-	}
-
-	pub(super) fn physical_len(&self) -> NonZero<usize> {
-		self.physical.len
-	}
-
-	pub(super) fn physical_start(&self) -> Frame {
-		self.physical.base
-	}
-
-	pub(super) fn physical_end(&self) -> Frame {
-		self.physical_start() + self.physical_len().get()
-	}
+	/// The underlying physical memory is discontiguous, but all allocated by the same
+	Discontiguous,
 }
 
 /// Returned from [`RawMapping::into_raw_parts()`] if the underlying physical memory is not contiguous
-/// 
+///
 /// See the documentation for [`into_raw_parts()`](RawMapping::into_raw_parts()) for more information.
 #[derive(Debug)]
-pub struct DiscontinuityError;
+pub struct DiscontiguityError;
 
 /// The raw type underlying all memory mappings.
 ///
@@ -443,14 +427,35 @@ pub struct DiscontinuityError;
 /// It will also manage the page tables to correctly unmap the memory when dropped.
 pub struct RawMapping<'phys_allocator, R: Mappable, A: VirtualAllocator> {
 	raw: PhantomData<R>,
+
+	/// The virtual allocator used for memory allocation
 	virtual_allocator: ManuallyDrop<A>,
-	inner: RawMappingInner<'phys_allocator>
+
+	/// Whether the underlying physical memory is contiguous or not
+	contiguity: RawMappingContiguity,
+
+	/// The first page in the mapping that is mapped to physical memory.
+	/// The region of virtual memory from `virtual_valid_start` to `virtual_valid_start + physical_length` is mapped.
+	virtual_valid_start: Page,
+	
+	/// The number of physical pages allocated to the mapping
+	physical_len: NonZero<usize>,
+
+	/// The physical allocator used for memory allocation
+	allocator: &'phys_allocator dyn BackingAllocator
 }
 
 impl<R: Mappable, A: VirtualAllocator> Debug for RawMapping<'_, R, A> {
 	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
 		f.debug_struct("RawMapping")
-		 .field("physical", &self.inner.physical)
+		 .field(
+			 "physical_base",
+			 match self.physical_start() {
+				 Ok(ref frame) => frame,
+				 Err(_) => &"<discontiguous>",
+			 }
+		 )
+		 .field("physical_length", &self.physical_len().get())
 		 .field("virtual_base", &self.virtual_start())
 		 .field("virtual_valid_start", &self.virtual_valid_start())
 		 .field("virtual_allocator", &"<virtual allocator>")
@@ -460,16 +465,16 @@ impl<R: Mappable, A: VirtualAllocator> Debug for RawMapping<'_, R, A> {
 
 impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A> {
 	/// Create a new memory mapping with the given configuration
-	/// 
+	///
 	/// All physical memory used for the initial allocation will be contiguous.
 	/// This may change in future.
-	/// 
+	///
 	/// # Errors
-	/// 
+	///
 	/// If the required physical or virtual memory could not be allocation, [`AllocError`] is returned.
-	/// 
+	///
 	/// # Panics
-	/// 
+	///
 	/// If the page tables already contained a mapping for the newly allocated virtual memory.
 	pub fn new(config: Config<'phys_alloc, A>, reason: u16) -> Result<Self, AllocError> {
 		let Config { length, physical_allocator, virtual_allocator, physical_location, .. } = config;
@@ -480,11 +485,12 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 		let physical_mem = OwnedFrames::xnew(physical_len, physical_allocator, physical_location.into())?;
 		let virtual_mem = OwnedPages::new_with(virtual_len, virtual_allocator)?;
 
-		let physical_base = physical_mem.base;
+		let (physical_base, _, _) = physical_mem.into_raw_parts();
 		let (virtual_base, _, virtual_allocator) = virtual_mem.into_raw_parts();
 		let offset_base = virtual_base + R::physical_start_offset_from_virtual();
 
 		// TODO: huge pages
+		// FIXME: memory leak of physical and virtual memory if this fails
 		let mut page_table = unsafe { crate::bridge::paging::__popcorn_paging_get_ktable() };
 		for (frame, page) in (0..physical_len.get()).map(|i| (physical_base + i, offset_base + i)) {
 			unsafe { crate::bridge::paging::__popcorn_paging_ktable_map_page(&mut page_table, page, frame, reason) }
@@ -493,24 +499,36 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 
 		Ok(Self {
 			raw: PhantomData,
-			inner: RawMappingInner {
-				physical: physical_mem,
-				virtual_valid_start: offset_base
-			},
-			virtual_allocator: ManuallyDrop::new(virtual_allocator)
+			virtual_allocator: ManuallyDrop::new(virtual_allocator),
+			contiguity: RawMappingContiguity::Contiguous(physical_base),
+			virtual_valid_start: offset_base,
+			physical_len,
+			allocator: physical_allocator,
 		})
 	}
 
 	/// Destructure into the underlying [`OwnedFrames`] and [`OwnedPages`] that back the allocation
-	/// 
+	///
 	/// Depending on the implementation of [`Mappable`] used, these may be different length.
 	/// These can be turned back into a [`RawMapping`] by calling [`from_raw_parts()`].
-	/// 
+	///
 	/// # Errors
-	/// 
+	///
 	/// If the underlying physical memory is not contiguous, and so cannot be represented as a single instance
-	/// of [`OwnedFrames`], [`DiscontinuityError`] is returned.
-	pub fn into_raw_parts(mut self) -> Result<(OwnedFrames<'phys_alloc>, OwnedPages<A>), DiscontinuityError> {
+	/// of [`OwnedFrames`], [`DiscontiguityError`] is returned.
+	pub fn into_raw_parts(mut self) -> Result<(OwnedFrames<'phys_alloc>, OwnedPages<A>), DiscontiguityError> {
+		let frames = unsafe {
+			let RawMappingContiguity::Contiguous(base_frame) = self.contiguity else {
+				return Err(DiscontiguityError);
+			};
+			
+			OwnedFrames::from_raw_parts(
+				base_frame,
+				self.physical_len(),
+				self.allocator,
+			)
+		};
+		
 		let virtual_allocator = unsafe { ManuallyDrop::take(&mut self.virtual_allocator) };
 		let pages = unsafe {
 			OwnedPages::from_raw_parts(
@@ -520,22 +538,23 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 			)
 		};
 
-		let this = ManuallyDrop::new(self);
-		Ok((unsafe { ptr::read(&this.inner.physical) }, pages))
+		core::mem::forget(self);
+		Ok((frames, pages))
 	}
 
 	pub unsafe fn from_raw_parts(frames: OwnedFrames<'phys_alloc>, pages: OwnedPages<A>) -> Self {
 		let (virtual_base, actual_vlen, virtual_allocator) = pages.into_raw_parts();
-		let correct_vlen = R::physical_length_to_virtual_length(frames.len);
+		let (physical_base, physical_len, physical_allocator) = frames.into_raw_parts();
+		let correct_vlen = R::physical_length_to_virtual_length(physical_len);
 		debug_assert_eq!(actual_vlen, correct_vlen);
 
 		Self {
 			raw: PhantomData,
-			inner: RawMappingInner {
-				physical: frames,
-				virtual_valid_start: virtual_base + R::physical_start_offset_from_virtual()
-			},
-			virtual_allocator: ManuallyDrop::new(virtual_allocator)
+			virtual_allocator: ManuallyDrop::new(virtual_allocator),
+			contiguity: RawMappingContiguity::Contiguous(physical_base),
+			virtual_valid_start: virtual_base + R::physical_start_offset_from_virtual(),
+			physical_len,
+			allocator: physical_allocator,
 		}
 	}
 
@@ -548,7 +567,7 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 	}
 
 	fn virtual_valid_start(&self) -> Page {
-		self.inner.virtual_valid_start()
+		self.virtual_valid_start
 	}
 
 	pub fn virtual_end(&self) -> Page {
@@ -556,15 +575,21 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 	}
 
 	pub fn physical_len(&self) -> NonZero<usize> {
-		self.inner.physical_len()
+		self.physical_len
 	}
 
-	pub fn physical_start(&self) -> Frame {
-		self.inner.physical_start()
+	pub fn physical_start(&self) -> Result<Frame, DiscontiguityError> {
+		match self.contiguity {
+			RawMappingContiguity::Contiguous(base_frame) => Ok(base_frame),
+			RawMappingContiguity::Discontiguous => Err(DiscontiguityError),
+		}
 	}
 
-	pub fn physical_end(&self) -> Frame {
-		self.inner.physical_end()
+	pub fn physical_end(&self) -> Result<Frame, DiscontiguityError> {
+		match self.contiguity {
+			RawMappingContiguity::Contiguous(base_frame) => Ok(base_frame + self.physical_len().get()),
+			RawMappingContiguity::Discontiguous => Err(DiscontiguityError),
+		}
 	}
 }
 
@@ -578,6 +603,18 @@ impl<R: Mappable, A: VirtualAllocator> Drop for RawMapping<'_, R, A> {
 			unsafe { crate::bridge::paging::__popcorn_paging_ktable_unmap_page(&mut page_table, page) }
 					.expect("Virtual memory uniquely owned by this mmap so shouldn't be unmapped");
 		}
+
+		let _frames = unsafe {
+			let RawMappingContiguity::Contiguous(base_frame) = self.contiguity else {
+				todo!("Properly drop discontiguous mmap");
+			};
+
+			OwnedFrames::from_raw_parts(
+				base_frame,
+				self.physical_len(),
+				self.allocator,
+			)
+		};
 
 		let virtual_allocator = unsafe { ManuallyDrop::take(&mut self.virtual_allocator) };
 		let _pages = unsafe {

--- a/kernel_api/src/memory/mapping.rs
+++ b/kernel_api/src/memory/mapping.rs
@@ -341,6 +341,8 @@ pub struct Config<'physical_allocator, A: VirtualAllocator> {
 
 impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 	/// Creates a new [mapping](self) configuration with default options
+	/// 
+	/// `length` is specified in pages
 	///
 	/// The default options are not guaranteed, but at the moment are:
 	/// - physical and virtual locations: anywhere
@@ -386,8 +388,6 @@ impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 	}
 
 	/// Set the physical location of the low address of the mapping
-	///
-	/// This is currently ignored
 	pub fn physical_location(self, location: Location<Frame>) -> Self {
 		Config {
 			physical_location: location,
@@ -592,6 +592,46 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 			RawMappingContiguity::Discontiguous => Err(DiscontiguityError),
 		}
 	}
+
+	/// Attempts to resize the allocation to `new_len` without moving the allocation
+	/// 
+	/// If the allocation could be resized, the [`Page`] corresponding to the previous end of the mapping.
+	/// If it could not be resized, it returns the [`AllocError`] from the underlying allocators.
+	pub fn resize_in_place(&mut self, new_len: NonZero<usize>) -> Result<Page, AllocError> {
+		if new_len == self.physical_len() { return Ok(self.virtual_end()); }
+
+		let original_physical_allocator = self.allocator;
+
+		if new_len < self.physical_len() {
+			todo!("actually free and unmap the extra memory")
+		} else {
+			let extra_len: NonZero<usize> = new_len.get().checked_sub(self.physical_len().get())
+			                             .expect("`new_len` is checked to be greater than `physical_len`")
+										.try_into()
+										.expect("`new_len` is checked to be not equal to `physical_len`");
+
+			let extra_virtual_mem = Global.allocate_contiguous_at(self.virtual_end(), extra_len.get())?; // FIXME: use OwnedPages
+
+			debug_assert_eq!(self.virtual_end(), extra_virtual_mem);
+			
+			// TODO: huge pages
+			let mut page_table = unsafe { crate::bridge::paging::__popcorn_paging_get_ktable() };
+
+			let extra_physical_mem = OwnedFrames::xnew(extra_len, original_physical_allocator, super::allocator::Location::Any)?;
+			let (start_frame, _, _) = extra_physical_mem.into_raw_parts();
+
+			// FIXME: memory leak of physical and virtual memory if this fails
+			// FIXME: can't assume ktable depending on AddressSpace once #43 is sorted
+			// FIXME: this is probably wrong if the extra unmapped virtual memory is after the physical memory, not before
+			for (frame, page) in (0..extra_len.get()).map(|i| (start_frame + i, extra_virtual_mem + i)) {
+				unsafe { crate::bridge::paging::__popcorn_paging_ktable_map_page(&mut page_table, page, frame, 25) }
+						.expect("todo");
+			}
+
+			self.physical_len = new_len;
+			Ok(extra_virtual_mem)
+		}
+	}
 }
 
 impl<R: Mappable, A: VirtualAllocator> Drop for RawMapping<'_, R, A> {
@@ -621,7 +661,7 @@ impl<R: Mappable, A: VirtualAllocator> Drop for RawMapping<'_, R, A> {
 					crate::bridge::paging::__popcorn_paging_ktable_translate_page(&mut page_table, page)
 							.expect("Virtual memory uniquely owned by this mmap so shouldn't be unmapped")
 				});
-				
+
 				let drop_frame_range = |(frame, len)| {
 					let _frames = unsafe { OwnedFrames::from_raw_parts(
 						frame,
@@ -629,7 +669,7 @@ impl<R: Mappable, A: VirtualAllocator> Drop for RawMapping<'_, R, A> {
 						self.allocator,
 					) };
 				};
-				
+
 				// Group the frames into contiguous chunks
 				// First convert into a tuple of `(start, len)`, where each is of len 1
 				// Then reduce: if the end of one frame range is the start of the next,

--- a/kernel_api/src/memory/mapping.rs
+++ b/kernel_api/src/memory/mapping.rs
@@ -414,6 +414,9 @@ impl RawMappingInner<'_> {
 	}
 }
 
+#[derive(Debug)]
+pub struct DiscontinuityError;
+
 /// The raw type underlying all memory mappings.
 ///
 /// This will allocate any required memory when created, and register any lazily mapped memory as such.
@@ -436,6 +439,8 @@ impl<R: Mappable, A: VirtualAllocator> Debug for RawMapping<'_, R, A> {
 }
 
 impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A> {
+	/// All physical memory used for the initial allocation will be contiguous.
+	/// This may change in future.
 	pub fn new(config: Config<'phys_alloc, A>, reason: u16) -> Result<Self, AllocError> {
 		let Config { length, physical_allocator, virtual_allocator, physical_location, .. } = config;
 
@@ -466,7 +471,7 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 		})
 	}
 
-	pub fn into_raw_parts(mut self) -> (OwnedFrames<'phys_alloc>, OwnedPages<A>) {
+	pub fn into_raw_parts(mut self) -> Result<(OwnedFrames<'phys_alloc>, OwnedPages<A>), DiscontinuityError> {
 		let virtual_allocator = unsafe { ManuallyDrop::take(&mut self.virtual_allocator) };
 		let pages = unsafe {
 			OwnedPages::from_raw_parts(
@@ -477,7 +482,7 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 		};
 
 		let this = ManuallyDrop::new(self);
-		(unsafe { ptr::read(&this.inner.physical) }, pages)
+		Ok((unsafe { ptr::read(&this.inner.physical) }, pages))
 	}
 
 	pub unsafe fn from_raw_parts(frames: OwnedFrames<'phys_alloc>, pages: OwnedPages<A>) -> Self {

--- a/kernel_api/src/memory/mapping.rs
+++ b/kernel_api/src/memory/mapping.rs
@@ -341,6 +341,13 @@ pub struct Config<'physical_allocator, A: VirtualAllocator> {
 
 impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 	/// Creates a new [mapping](self) configuration with default options
+	/// 
+	/// The default options are not guaranteed, but at the moment are:
+	/// - physical and virtual locations: anywhere
+	/// - lazily allocated
+	/// - Highmem physical allocator
+	/// - Global virtual allocator
+	/// - Readable, writable and executable
 	pub fn new(length: NonZero<usize>) -> Config<'static, Global> {
 		Config {
 			physical_location: Location::Any,
@@ -353,6 +360,9 @@ impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 		}
 	}
 
+	/// Set the physical allocator to use
+	/// 
+	/// This is used for both the underlying memory as well as any page tables that need creating
 	pub fn physical_allocator<'a>(self, allocator: &'a dyn BackingAllocator) -> Config<'a, A> {
 		Config {
 			physical_allocator: allocator,
@@ -360,6 +370,7 @@ impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 		}
 	}
 
+	/// Set the virtual allocator to use
 	pub fn virtual_allocator<New: VirtualAllocator>(self, allocator: New) -> Config<'physical_allocator, New> {
 		Config {
 			virtual_allocator: allocator,
@@ -374,6 +385,9 @@ impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 		}
 	}
 
+	/// Set the physical location of the low address of the mapping
+	///
+	/// This is currently ignored
 	pub fn physical_location(self, location: Location<Frame>) -> Self {
 		Config {
 			physical_location: location,
@@ -381,6 +395,9 @@ impl<'physical_allocator, A: VirtualAllocator> Config<'physical_allocator, A> {
 		}
 	}
 
+	/// Set the virtual location of the low address of the mapping
+	/// 
+	/// This is currently ignored
 	pub fn virtual_location(self, location: Location<Page>) -> Self {
 		Config {
 			_virtual_location: location,
@@ -414,6 +431,9 @@ impl RawMappingInner<'_> {
 	}
 }
 
+/// Returned from [`RawMapping::into_raw_parts()`] if the underlying physical memory is not contiguous
+/// 
+/// See the documentation for [`into_raw_parts()`](RawMapping::into_raw_parts()) for more information.
 #[derive(Debug)]
 pub struct DiscontinuityError;
 
@@ -439,8 +459,18 @@ impl<R: Mappable, A: VirtualAllocator> Debug for RawMapping<'_, R, A> {
 }
 
 impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A> {
+	/// Create a new memory mapping with the given configuration
+	/// 
 	/// All physical memory used for the initial allocation will be contiguous.
 	/// This may change in future.
+	/// 
+	/// # Errors
+	/// 
+	/// If the required physical or virtual memory could not be allocation, [`AllocError`] is returned.
+	/// 
+	/// # Panics
+	/// 
+	/// If the page tables already contained a mapping for the newly allocated virtual memory.
 	pub fn new(config: Config<'phys_alloc, A>, reason: u16) -> Result<Self, AllocError> {
 		let Config { length, physical_allocator, virtual_allocator, physical_location, .. } = config;
 
@@ -471,6 +501,15 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 		})
 	}
 
+	/// Destructure into the underlying [`OwnedFrames`] and [`OwnedPages`] that back the allocation
+	/// 
+	/// Depending on the implementation of [`Mappable`] used, these may be different length.
+	/// These can be turned back into a [`RawMapping`] by calling [`from_raw_parts()`].
+	/// 
+	/// # Errors
+	/// 
+	/// If the underlying physical memory is not contiguous, and so cannot be represented as a single instance
+	/// of [`OwnedFrames`], [`DiscontinuityError`] is returned.
 	pub fn into_raw_parts(mut self) -> Result<(OwnedFrames<'phys_alloc>, OwnedPages<A>), DiscontinuityError> {
 		let virtual_allocator = unsafe { ManuallyDrop::take(&mut self.virtual_allocator) };
 		let pages = unsafe {

--- a/kernel_api/src/memory/mapping.rs
+++ b/kernel_api/src/memory/mapping.rs
@@ -618,12 +618,16 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 			let mut page_table = unsafe { crate::bridge::paging::__popcorn_paging_get_ktable() };
 
 			let extra_physical_mem = OwnedFrames::xnew(extra_len, original_physical_allocator, super::allocator::Location::Any)?;
-			let (start_frame, _, _) = extra_physical_mem.into_raw_parts();
+			let (new_start_frame, _, _) = extra_physical_mem.into_raw_parts();
+
+			if let RawMappingContiguity::Contiguous(base_frame) = self.contiguity {
+				if base_frame + self.physical_len.get() != base_frame { self.contiguity = RawMappingContiguity::Discontiguous; }
+			}
 
 			// FIXME: memory leak of physical and virtual memory if this fails
 			// FIXME: can't assume ktable depending on AddressSpace once #43 is sorted
 			// FIXME: this is probably wrong if the extra unmapped virtual memory is after the physical memory, not before
-			for (frame, page) in (0..extra_len.get()).map(|i| (start_frame + i, extra_virtual_mem + i)) {
+			for (frame, page) in (0..extra_len.get()).map(|i| (new_start_frame + i, extra_virtual_mem + i)) {
 				unsafe { crate::bridge::paging::__popcorn_paging_ktable_map_page(&mut page_table, page, frame, 25) }
 						.expect("todo");
 			}

--- a/kernel_api/src/memory/mapping.rs
+++ b/kernel_api/src/memory/mapping.rs
@@ -600,23 +600,64 @@ impl<R: Mappable, A: VirtualAllocator> Drop for RawMapping<'_, R, A> {
 
 		// fixme: can't assume ktable depending on AddressSpace once #43 is sorted
 		let mut page_table = unsafe { crate::bridge::paging::__popcorn_paging_get_ktable() };
+
+		// If the underlying memory is discontiguous, we need to find the physical memory chunks via the page tables
+		// and deallocate them before unmapping. To reduce the number of allocator calls, we merge contiguous chunks
+		// together. Since the concept of a single 'allocation' does not exist in the physical allocator, this is
+		// allowed regardless of whether the chunks were allocated in one go.
+		// If the memory is contiguous, we deallocate it in one go by converting it to an OwnedFrames object and
+		// immediately dropping it.
+		match self.contiguity {
+			RawMappingContiguity::Contiguous(base_frame) => {
+				let _frames = unsafe { OwnedFrames::from_raw_parts(
+					base_frame,
+					self.physical_len(),
+					self.allocator,
+				) };
+			},
+			RawMappingContiguity::Discontiguous => {
+				let page_iter = (0..self.physical_len().get()).map(|i| self.virtual_valid_start() + i);
+				let frame_iter = page_iter.map(|page| unsafe {
+					crate::bridge::paging::__popcorn_paging_ktable_translate_page(&mut page_table, page)
+							.expect("Virtual memory uniquely owned by this mmap so shouldn't be unmapped")
+				});
+				
+				let drop_frame_range = |(frame, len)| {
+					let _frames = unsafe { OwnedFrames::from_raw_parts(
+						frame,
+						len,
+						self.allocator,
+					) };
+				};
+				
+				// Group the frames into contiguous chunks
+				// First convert into a tuple of `(start, len)`, where each is of len 1
+				// Then reduce: if the end of one frame range is the start of the next,
+				// combine into a range with the new length; otherwise, take the already
+				// combined chunks, and deallocate in one go
+				let last_chunk = frame_iter.map(|frame| (frame, NonZero::<usize>::new(1).unwrap()))
+						.reduce(|prev_group, new_group| {
+							if prev_group.0 + prev_group.1.get() == new_group.0
+								&& let Some(combined_len) = prev_group.1.checked_add(new_group.1.get()) { // If the length overflows, just drop in two chunks
+								// contiguous, so merge
+								(prev_group.0, combined_len)
+							} else {
+								// discontigous, so drop the existing set
+								drop_frame_range(prev_group);
+								new_group
+							}
+						});
+				if let Some(last_chunk) = last_chunk {
+					drop_frame_range(last_chunk);
+				}
+			},
+		}
+
 		for page in (0..self.physical_len().get()).map(|i| self.virtual_valid_start() + i) {
 			debug!("unmapping page {page:x?}");
 			unsafe { crate::bridge::paging::__popcorn_paging_ktable_unmap_page(&mut page_table, page) }
 					.expect("Virtual memory uniquely owned by this mmap so shouldn't be unmapped");
 		}
-
-		let _frames = unsafe {
-			let RawMappingContiguity::Contiguous(base_frame) = self.contiguity else {
-				todo!("Properly drop discontiguous mmap");
-			};
-
-			OwnedFrames::from_raw_parts(
-				base_frame,
-				self.physical_len(),
-				self.allocator,
-			)
-		};
 
 		let virtual_allocator = unsafe { ManuallyDrop::take(&mut self.virtual_allocator) };
 		let _pages = unsafe {

--- a/kernel_api/src/memory/mapping.rs
+++ b/kernel_api/src/memory/mapping.rs
@@ -491,6 +491,7 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 
 		// TODO: huge pages
 		// FIXME: memory leak of physical and virtual memory if this fails
+		// fixme: can't assume ktable depending on AddressSpace once #43 is sorted
 		let mut page_table = unsafe { crate::bridge::paging::__popcorn_paging_get_ktable() };
 		for (frame, page) in (0..physical_len.get()).map(|i| (physical_base + i, offset_base + i)) {
 			unsafe { crate::bridge::paging::__popcorn_paging_ktable_map_page(&mut page_table, page, frame, reason) }
@@ -597,6 +598,7 @@ impl<R: Mappable, A: VirtualAllocator> Drop for RawMapping<'_, R, A> {
 	fn drop(&mut self) {
 		debug!("mmap dropped: {self:x?}");
 
+		// fixme: can't assume ktable depending on AddressSpace once #43 is sorted
 		let mut page_table = unsafe { crate::bridge::paging::__popcorn_paging_get_ktable() };
 		for page in (0..self.physical_len().get()).map(|i| self.virtual_valid_start() + i) {
 			debug!("unmapping page {page:x?}");

--- a/kernel_api/src/memory/mapping.rs
+++ b/kernel_api/src/memory/mapping.rs
@@ -419,7 +419,7 @@ pub(super) enum RawMappingContiguity {
 ///
 /// See the documentation for [`into_contiguous_raw_parts()`](RawMapping::into_contiguous_raw_parts()) for more information.
 #[derive(Debug)]
-pub struct DiscontiguityError;
+pub struct DiscontiguityError(());
 
 /// The raw type underlying all memory mappings.
 ///
@@ -520,7 +520,7 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 	pub fn into_contiguous_raw_parts(mut self) -> Result<(OwnedFrames<'phys_alloc>, OwnedPages<A>), DiscontiguityError> {
 		let frames = unsafe {
 			let RawMappingContiguity::Contiguous(base_frame) = self.contiguity else {
-				return Err(DiscontiguityError);
+				return Err(DiscontiguityError(()));
 			};
 			
 			OwnedFrames::from_raw_parts(
@@ -582,14 +582,14 @@ impl<'phys_alloc, R: Mappable, A: VirtualAllocator> RawMapping<'phys_alloc, R, A
 	pub fn physical_start(&self) -> Result<Frame, DiscontiguityError> {
 		match self.contiguity {
 			RawMappingContiguity::Contiguous(base_frame) => Ok(base_frame),
-			RawMappingContiguity::Discontiguous => Err(DiscontiguityError),
+			RawMappingContiguity::Discontiguous => Err(DiscontiguityError(())),
 		}
 	}
 
 	pub fn physical_end(&self) -> Result<Frame, DiscontiguityError> {
 		match self.contiguity {
 			RawMappingContiguity::Contiguous(base_frame) => Ok(base_frame + self.physical_len().get()),
-			RawMappingContiguity::Discontiguous => Err(DiscontiguityError),
+			RawMappingContiguity::Discontiguous => Err(DiscontiguityError(())),
 		}
 	}
 


### PR DESCRIPTION
- Modify some of the current APIs that assume contiguous physical memory (`into_raw_parts()`, `physical_start()` and `physical_end()`)
- Allow a `RawMapping` to be backed by discontiguous physical memory
- Add `resize()` and `resize_in_place()` functions