### PR TITLE
Accelerate symbol map traversal using a `BTreeMap`

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -301,8 +301,9 @@ extern "sysv64" fn kstart(handoff_data: &'static utils::handoff::Data) -> ! {
 fn kmain(handoff_data: HandoffWrapper) -> ! {
 	let _ = logging::init();
 
-	let map = unsafe { handoff_data.log.symbol_map.map(|ptr| &*ptr.as_ptr().byte_add(0xffff_8000_0000_0000)) };
-	*panicking::SYMBOL_MAP.write() = map;
+	if let Some(map) = handoff_data.log.symbol_map {
+		panicking::SYMBOL_MAP.get_or_init(|| unsafe { map.byte_add(0xffff_8000_0000_0000).as_ref() });
+	}
 
 	trace!("Handoff data:\n{handoff_data:x?}");
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -38,6 +38,7 @@
 #![feature(build_hasher_default_const_new)]
 #![feature(min_specialization)]
 #![feature(doc_auto_cfg)]
+#![feature(btree_cursors)]
 
 #![feature(kernel_heap)]
 #![feature(kernel_allocation_new)]
@@ -390,6 +391,8 @@ fn kmain(handoff_data: HandoffWrapper) -> ! {
 
 		*memory::r#virtual::GLOBAL_VIRTUAL_ALLOCATOR.write() = Box::leak(Box::new(btree_alloc));
 	}
+
+	let _ = panicking::construct_symbol_tree();
 
 	unsafe {
 		hal::acpi::init_tables(handoff_data.rsdp.addr);

--- a/kernel/src/panicking.rs
+++ b/kernel/src/panicking.rs
@@ -4,10 +4,10 @@ use core::ptr;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use unwinding::abi::UnwindReasonCode;
 use unwinding::panic::catch_unwind as catch_unwind_impl;
-use kernel_api::sync::RwSpinlock;
+use kernel_api::sync::OnceLock;
 
 static PANIC_COUNT: AtomicUsize = AtomicUsize::new(0);
-pub static SYMBOL_MAP: RwSpinlock<Option<&'static [u8]>> = RwSpinlock::new(None);
+pub static SYMBOL_MAP: OnceLock<&'static [u8]> = OnceLock::new();
 
 pub fn catch_unwind<R, F: FnOnce() -> R + core::panic::UnwindSafe>(f: F) -> Result<R, Box<dyn Any + Send>> {
 	let res = catch_unwind_impl(f);
@@ -51,7 +51,7 @@ pub fn get_symbol_from_ip(ip: usize) -> Symbol {
 		}
 	}
 
-	let Some(map) = *SYMBOL_MAP.read() else { return Symbol { name: "[no symbols]", file: "" }; };
+	let Some(map) = SYMBOL_MAP.get() else { return Symbol { name: "[no symbols]", file: "" }; };
 	let iter = SymbolMapIterator {
 		index: 0,
 		str: map

--- a/kernel/src/panicking.rs
+++ b/kernel/src/panicking.rs
@@ -2,12 +2,16 @@
 use core::any::Any;
 use core::ptr;
 use core::sync::atomic::{AtomicUsize, Ordering};
+use core::ops::Bound;
+use core::iter;
 use unwinding::abi::UnwindReasonCode;
 use unwinding::panic::catch_unwind as catch_unwind_impl;
 use kernel_api::sync::OnceLock;
+use alloc::collections::btree_map::BTreeMap;
 
 static PANIC_COUNT: AtomicUsize = AtomicUsize::new(0);
 pub static SYMBOL_MAP: OnceLock<&'static [u8]> = OnceLock::new();
+static SYMBOL_TREE: OnceLock<BTreeMap<usize, Symbol>> = OnceLock::new();
 
 pub fn catch_unwind<R, F: FnOnce() -> R + core::panic::UnwindSafe>(f: F) -> Result<R, Box<dyn Any + Send>> {
 	let res = catch_unwind_impl(f);
@@ -15,40 +19,66 @@ pub fn catch_unwind<R, F: FnOnce() -> R + core::panic::UnwindSafe>(f: F) -> Resu
 	res
 }
 
+#[derive(Copy, Clone)]
 pub struct Symbol {
 	pub name: &'static str,
 	pub file: &'static str,
 }
 
-pub fn get_symbol_from_ip(ip: usize) -> Symbol {
-	struct SymbolMapIterator {
-		index: usize,
-		str: &'static [u8]
+impl Symbol {
+	const UNKNOWN: Symbol = Symbol { name: "[unknown]", file: "[unknown]" };
+}
+
+struct SymbolMapIterator {
+	index: usize,
+	str: &'static [u8]
+}
+
+impl Iterator for SymbolMapIterator {
+	type Item = (usize, Symbol);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		let original_idx = self.index;
+		if original_idx == self.str.len() { return None; }
+
+		let mut idx = original_idx;
+		while self.str[idx] != b'\n' { idx += 1; }
+
+		let data = core::str::from_utf8(&self.str[original_idx..idx]).ok()?;
+		let addr = &data[0..16];
+		let (name, file) = (&data[19..]).split_once('\t')?;
+		let file = match file.split_once(':') {
+			Some((file, _)) => file,
+			None => file
+		};
+		let addr = usize::from_str_radix(addr, 16).ok()?;
+
+		self.index = idx + 1;
+
+		Some((addr, Symbol { name, file }))
 	}
+	
+	fn size_hint(&self) -> (usize, Option<usize>) {
+		let len = self.str.iter().filter(|c| **c == b'\n').count();
+		(len, Some(len))
+	}
+}
 
-	impl Iterator for SymbolMapIterator {
-		type Item = (usize, &'static str, &'static str);
+pub struct EmptySymbolMapError;
+pub fn construct_symbol_tree() -> Result<(), EmptySymbolMapError> {
+	let Some(map) = SYMBOL_MAP.get() else { return Err(EmptySymbolMapError); };
+	let iter = SymbolMapIterator {
+		index: 0,
+		str: map
+	};
+	SYMBOL_TREE.get_or_init(|| BTreeMap::from_iter(iter::once((0, Symbol::UNKNOWN)).chain(iter)));
+	Ok(())
+}
 
-		fn next(&mut self) -> Option<Self::Item> {
-			let original_idx = self.index;
-			if original_idx == self.str.len() { return None; }
-
-			let mut idx = original_idx;
-			while self.str[idx] != b'\n' { idx += 1; }
-
-			let data = core::str::from_utf8(&self.str[original_idx..idx]).ok()?;
-			let addr = &data[0..16];
-			let (name, filename) = (&data[19..]).split_once('\t')?;
-			let filename = match filename.split_once(':') {
-				Some((filename, _)) => filename,
-				None => filename
-			};
-			let addr = usize::from_str_radix(addr, 16).ok()?;
-
-			self.index = idx + 1;
-
-			Some((addr, name, filename))
-		}
+pub fn get_symbol_from_ip(ip: usize) -> Symbol {
+	if let Some(symbol_tree) = SYMBOL_TREE.get() {
+		return *symbol_tree.upper_bound(Bound::Included(&ip)).peek_prev()
+			.expect("upper_bound returns a Cursor pointing to the gap after an element, so prev cannot be None unless the tree is empty").1;
 	}
 
 	let Some(map) = SYMBOL_MAP.get() else { return Symbol { name: "[no symbols]", file: "" }; };
@@ -56,13 +86,13 @@ pub fn get_symbol_from_ip(ip: usize) -> Symbol {
 		index: 0,
 		str: map
 	};
-	let mut sym_name = "[unknown]";
-	let mut sym_file = "[unknown]";
-	for (sym_addr, name, file) in iter {
+	
+	let mut last_sym = Symbol::UNKNOWN;
+	for (sym_addr, sym) in iter {
 		if sym_addr > ip { break; }
-		else if sym_addr != 0 { sym_name = name; sym_file = file; }
+		last_sym = sym;
 	}
-	Symbol { name: sym_name, file: sym_file }
+	return last_sym;
 }
 
 pub fn stack_trace_iter<F: FnMut(usize, Symbol)>(mut f: F) {

--- a/kernel_default_heap/src/lib.rs
+++ b/kernel_default_heap/src/lib.rs
@@ -54,9 +54,9 @@ impl Heap for SyncHeap {
         debug!("allocate {layout:?}");
 
         let guard = &mut *self.0.lock();
-        
+
         let Some(size) = NonZero::new(layout.size()) else { return Ok(NonNull::dangling()); };
-        
+
         let start = if let Some(mapping) = &mut guard.mapping {
             let start = guard.watermark.align_up_runtime(layout.align());
             let end = start + size.get();
@@ -65,7 +65,7 @@ impl Heap for SyncHeap {
                 debug!("Increment heap end");
                 // FIXME: HACK
                 let increment = isize::try_from(end - heap_end).map_err(|_| AllocError)?
-                        .div_ceil(4096)*10;
+                        .div_ceil(4096)*400;
                 let new_len = mapping.physical_len().checked_add(increment.unsigned_abs()).ok_or(AllocError)?;
                 debug!("Trying to remap");
                 mapping.resize_in_place(new_len)?;


### PR DESCRIPTION
Currently, when looking up symbols corresponding to addresses in a backtrace, a linear search is performed through all ~13k symbol names for every single address. This is quite slow, but could easily be made much faster by using a more performant data structure, such as a `BTreeMap`.