### PR TITLE
Fix ISO naming

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,7 +35,7 @@ jobs:
         if: success() && github.ref == 'refs/heads/trunk'
         uses: actions/upload-artifact@v4
         with:
-          name: Live ISO
+          name: Live ISO - ${{ matrix.logging }} ${{ matrix.preemptive }}
           path: |
             target/release/popcorn2.iso
   test:


### PR DESCRIPTION
upload-artifact@v4 broke calling all matrix run outputs "Live ISO"
this appends the matrix data to the end of the name