### PR TITLE
Hotfix: `inline_const_pat` feature removal

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -34,7 +34,6 @@
 #![feature(doc_auto_cfg)]
 #![feature(integer_atomics)]
 #![feature(arbitrary_self_types_pointers)]
-#![feature(inline_const_pat)]
 #![feature(macro_metavar_expr_concat)]
 
 #![feature(kernel_heap)]


### PR DESCRIPTION
(wasn't used anyway)