### PR TITLE
Replace #[thread_local] with custom percpu!() macro

### DIFF
--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -637,7 +637,7 @@ fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
 
             "mov eax, 0xead10ca1",
             "mov edx, 0xd", // edx:eax = 0xdead10cal
-            "mov ecx, 0xc0000100", // ecx = FSBase MSR
+            "mov ecx, 0xc0000101", // ecx = GSBase MSR
             "wrmsr",
 
             "jmp rsi",

--- a/kernel/src/hal/arch/amd64/linker.ld
+++ b/kernel/src/hal/arch/amd64/linker.ld
@@ -9,7 +9,7 @@ PHDRS {
     dynamic PT_DYNAMIC ;
     gnu_eh_frame 0x6474E550 FLAGS(0x4) ;
     lazy PT_LOAD FLAGS(0x20006) ;
-    tls PT_TLS FLAGS(0x406) ;
+    percpu PT_TLS FLAGS(0x406) ;
 }
 
 SECTIONS {
@@ -133,15 +133,12 @@ SECTIONS {
 	} :data :dynamic
 
     . = ALIGN(4K);
-	.tdata :
+	.percpu :
 	{
-	    *(.tdata .tdata.*)
-	} :tls
-
-	.tbss :
-	{
-	    *(.tbss .tbss.*)
-	}
+	    __percpu_start = .;
+	    *(.percpu .percpu.*)
+	    __percpu_end = .;
+	} :percpu
 
 	. = ALIGN(4K);
 	PROVIDE(__popcorn_vmem_bootstrap_start = .);

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -94,14 +94,7 @@ unsafe impl Hal for Amd64Hal {
 	}
 
 	unsafe fn load_tls(ptr: *mut u8) {
-		let tls_self_ptr_low = ptr as usize as u32;
-		let tls_self_ptr_high = ((ptr as usize) >> 32) as u32;
-		unsafe {
-			asm!(
-				"wrmsr",
-				in("edx") tls_self_ptr_high, in("eax") tls_self_ptr_low, in("ecx") 0xc0000100u32 // FSBase MSR
-			);
-		}
+		msr::wrmsr(msr::GSBase, ptr.addr() as _);
 	}
 
 	unsafe fn construct_tables() -> (Self::KTableTy, Self::TTableTy) {
@@ -264,6 +257,7 @@ pub(super) mod msr {
 
 	pub const IA32_APIC_BASE: ModelSpecificRegister = ModelSpecificRegister(0x1B);
 	pub const IA32_TSC_DEADLINE: ModelSpecificRegister = ModelSpecificRegister(0x6e0);
+	pub const GSBase: ModelSpecificRegister = ModelSpecificRegister(0xc0000101);
 
 	// fixme: is this always safe?
 	pub fn rdmsr(msr: ModelSpecificRegister) -> u64 {

--- a/kernel/src/hal/interrupts_v2/mod.rs
+++ b/kernel/src/hal/interrupts_v2/mod.rs
@@ -1,3 +1,4 @@
+use crate::prelude::*;
 use core::cell::OnceCell;
 
 /// An interrupt vector on a core
@@ -13,8 +14,7 @@ pub struct Vector(pub usize);
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Line(pub usize);
 
-#[thread_local]
-static LOCAL_INTERRUPT_CONTROLLER: OnceCell<LocalInterruptControllerMeta> = OnceCell::new();
+percpu!(static LOCAL_INTERRUPT_CONTROLLER: OnceCell<LocalInterruptControllerMeta> = OnceCell::new());
 
 trait LocalInterruptController {
 	

--- a/kernel/src/hal/timing.rs
+++ b/kernel/src/hal/timing.rs
@@ -3,18 +3,17 @@ use core::cell::OnceCell;
 use kernel_api::time::Instant;
 use crate::hal::interrupts_v2::Vector;
 
-#[thread_local]
-static LOCAL_TIMER: OnceCell<TimerMeta> = OnceCell::new();
+percpu!(static LOCAL_TIMER: OnceCell<TimerMeta> = OnceCell::new());
 
 pub(super) fn init_local_timer(timer: TimerMeta) {
-	match LOCAL_TIMER.try_insert(timer) {
+	match LOCAL_TIMER().try_insert(timer) {
 		Ok(_) => {},
 		Err(_) => panic!("`LOCAL_TIMER` already initialised"),
 	}
 }
 
 pub fn local_timer() -> &'static TimerMeta {
-	unsafe { core::mem::transmute::<_, &'static _>(LOCAL_TIMER.get().expect("`local_timer` not yet initialised")) }
+	LOCAL_TIMER().get().expect("`local_timer` not yet initialised")
 }
 
 pub trait Timer {

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -3,13 +3,12 @@ use core::cell::OnceCell;
 use crate::hal;
 use crate::hal::interrupts_v2::Vector;
 
-#[thread_local]
-static DEFER_IRQ: OnceCell<Box<dyn Fn()>> = OnceCell::new();
+percpu!(static DEFER_IRQ: OnceCell<Box<dyn Fn()>> = OnceCell::new());
 
 pub fn global_irq_handler(vector: Vector) {
 	if vector == hal::IPI_VECTOR {
 		// todo: check actual IPI cause instead of blindly assuming self-ipi defer
-		DEFER_IRQ.get().expect("No defer irq handler")();
+		DEFER_IRQ().get().expect("No defer irq handler")();
 		hal::get_and_disable_interrupts();
 		hal::send_local_eoi(vector);
 	} else if vector == hal::SPURIOUS_VECTOR {
@@ -26,5 +25,5 @@ pub fn global_irq_handler(vector: Vector) {
 
 // todo: no
 pub fn set_defer_irq(f: impl Fn() + 'static) {
-	DEFER_IRQ.set(Box::new(f)).unwrap_or_else(|_| panic!());
+	DEFER_IRQ().set(Box::new(f)).unwrap_or_else(|_| panic!());
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -110,6 +110,7 @@ mod interrupts;
 mod ipc;
 mod prelude;
 mod io_ext;
+mod percpu;
 
 #[cfg(test)]
 pub mod test_harness;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -15,7 +15,6 @@
 #![feature(inherent_associated_types)]
 #![feature(pointer_like_trait)]
 #![feature(int_roundings)]
-#![feature(thread_local)]
 #![feature(vec_into_raw_parts)]
 #![feature(strict_provenance_atomic_ptr)]
 #![feature(maybe_uninit_uninit_array_transpose)]
@@ -115,11 +114,10 @@ mod percpu;
 #[cfg(test)]
 pub mod test_harness;
 
-#[thread_local]
-static FOO: UnsafeCell<usize> = UnsafeCell::new(6);
+percpu!(static FOO: UnsafeCell<usize> = UnsafeCell::new(6));
 
 fn get_foo() -> usize {
-	unsafe { *FOO.get() }
+	unsafe { *FOO().get() }
 }
 
 #[macro_export]

--- a/kernel/src/percpu.rs
+++ b/kernel/src/percpu.rs
@@ -16,14 +16,13 @@ macro_rules! percpu {
             let val: *mut $ty;
             unsafe {
                 ::core::arch::asm!(
-                    "mov {}, gs:[{}]",
+                    "mov {}, gs:[0]",
                     out(reg) val,
-                    const { ::core::ptr::addr_of!(__percpu_end).offset_from(::core::ptr::addr_of!(PERCPU).cast::<u8>()) },
                     options(nostack, preserves_flags)
                 );
             }
             unsafe {
-                &*val
+                &*val.byte_offset(::core::ptr::addr_of!(__percpu_end).offset_from(::core::ptr::addr_of!(PERCPU).cast::<u8>()))
             }
         }
     };

--- a/kernel/src/percpu.rs
+++ b/kernel/src/percpu.rs
@@ -22,7 +22,7 @@ macro_rules! percpu {
                 );
             }
             unsafe {
-                &*val.byte_offset(::core::ptr::addr_of!(__percpu_end).offset_from(::core::ptr::addr_of!(PERCPU).cast::<u8>()))
+                &*val.byte_offset(::core::ptr::addr_of!(PERCPU).byte_offset_from(::core::ptr::addr_of!(__percpu_end)))
             }
         }
     };

--- a/kernel/src/percpu.rs
+++ b/kernel/src/percpu.rs
@@ -1,0 +1,32 @@
+macro_rules! percpu {
+    ($vis:vis static $ident:ident: $ty:ty = $init:expr) => {
+        #[inline(always)]
+        $vis fn $ident() -> &'static $ty {
+            #[repr(transparent)]
+            struct Wrap($ty);
+
+            unsafe impl Sync for Wrap {}
+
+            #[link_section = concat!(".percpu.", stringify!($ident))]
+            #[used]
+            static PERCPU: Wrap = Wrap($init);
+
+            extern "C" { static __percpu_end: u8; }
+
+            let val: *mut $ty;
+            unsafe {
+                ::core::arch::asm!(
+                    "mov {}, gs:[{}]",
+                    out(reg) val,
+                    const { ::core::ptr::addr_of!(__percpu_end).offset_from(::core::ptr::addr_of!(PERCPU).cast::<u8>()) },
+                    options(nostack, preserves_flags)
+                );
+            }
+            unsafe {
+                &*val
+            }
+        }
+    };
+}
+
+pub(crate) use percpu;

--- a/kernel/src/percpu.rs
+++ b/kernel/src/percpu.rs
@@ -1,5 +1,5 @@
 macro_rules! percpu {
-    ($vis:vis static $ident:ident: $ty:ty = $init:expr) => {
+    ($vis:vis static $ident:ident: $ty:ty = $init:expr $(;)?) => {
         #[inline(always)]
         $vis fn $ident() -> &'static $ty {
             #[repr(transparent)]

--- a/kernel/src/prelude.rs
+++ b/kernel/src/prelude.rs
@@ -9,6 +9,6 @@ pub use alloc::format;
 // Commonly used kernel imports
 pub use log::{error, warn, info, debug, trace};
 pub use crate::{sprint, sprintln, yeet};
-// todo: thread_local!
+pub(crate) use crate::percpu::percpu;
 
 pub use crate::io_ext::IoExt as _;

--- a/kernel/src/threading/scheduler.rs
+++ b/kernel/src/threading/scheduler.rs
@@ -29,8 +29,7 @@ use crate::threading::{PointerView, SharedView, ThreadControlBlock, ThreadState}
 mod tickless_round_robin;
 
 /// The [`Scheduler`] for the current core
-#[thread_local]
-static SCHEDULER: OnceCell<IrqCell<tickless_round_robin::TicklessRoundRobin>> = OnceCell::new();
+percpu!(static SCHEDULER: OnceCell<IrqCell<tickless_round_robin::TicklessRoundRobin>> = OnceCell::new());
 
 /// [`Injector`]s to add new threads to each core
 static SCHEDULER_INJECTORS: Spinlock<Vec<Box<dyn Injector>>> = Spinlock::new(vec![]);
@@ -91,9 +90,9 @@ pub enum SchedulerSwitchState<'a> {
 }
 
 pub(super) fn create_scheduler_for_current_core(running_thread: ThreadPointer) -> CoreId {
-	debug_assert!(SCHEDULER.get().is_none(), "Scheduler already initialised");
+	debug_assert!(SCHEDULER().get().is_none(), "Scheduler already initialised");
 	let (scheduler, injector, _stealer) = <tickless_round_robin::TicklessRoundRobin as Scheduler>::new(running_thread);
-	SCHEDULER.set(IrqCell::new(scheduler))
+	SCHEDULER().set(IrqCell::new(scheduler))
 			.expect("Scheduler already initialised");
 	let mut guard = SCHEDULER_INJECTORS.lock();
 	guard.push(injector);
@@ -101,9 +100,8 @@ pub(super) fn create_scheduler_for_current_core(running_thread: ThreadPointer) -
 }
 
 pub(super) fn local_scheduler() -> &'static IrqCell<impl Scheduler + Debug> {
-	let s = SCHEDULER.get()
-			.expect("Scheduler not yet initialised");
-	unsafe { transmute::<&IrqCell<tickless_round_robin::TicklessRoundRobin>, &'static IrqCell<tickless_round_robin::TicklessRoundRobin>>(s) }
+	SCHEDULER().get()
+			.expect("Scheduler not yet initialised")
 }
 
 /// Enqueues a thread onto a core such that system load stays balanced

--- a/kernel/src/threading/sleeping.rs
+++ b/kernel/src/threading/sleeping.rs
@@ -8,6 +8,6 @@ pub fn sleep(duration: Duration) {
 }
 
 pub fn sleep_until(wake_time: Instant) {
-	let reason = super::park(&[&LOCAL_TIMER_QUEUE.waker_for(wake_time)]).expect("Failed to park");
+	let reason = super::park(&[&LOCAL_TIMER_QUEUE().waker_for(wake_time)]).expect("Failed to park");
 	debug_assert_eq!(reason, WakeReason::Timeout, "`sleep` should only wake due to a timeout");
 }

--- a/kernel/src/threading/yielding.rs
+++ b/kernel/src/threading/yielding.rs
@@ -1,3 +1,4 @@
+use crate::prelude::*;
 use core::cell::{LazyCell, UnsafeCell};
 use core::mem::ManuallyDrop;
 use core::ptr;
@@ -11,30 +12,31 @@ use crate::memory::paging::ktable;
 use crate::threading::scheduler::SchedulerSwitchState;
 use super::{scheduler, WakeReason, ThreadState, scheduler::Scheduler, ThreadPointer, PointerView, Thread, ThreadControlBlock, ThreadId};
 
-#[thread_local]
-static IDLE_THREAD: LazyCell<(ThreadId, Thread, UnsafeCell<ThreadPointer>)> = LazyCell::new(|| {
-	extern "C" fn idle_loop(_: usize) -> ! {
-		loop {
-			hal::wait_for_interrupt();
-			yield_now();
+percpu! {
+	static IDLE_THREAD: LazyCell<(ThreadId, Thread, UnsafeCell<ThreadPointer>)> = LazyCell::new(|| {
+		extern "C" fn idle_loop(_: usize) -> ! {
+			loop {
+				hal::wait_for_interrupt();
+				yield_now();
+			}
 		}
-	}
-
-	let ttable = TTableTy::new(&*ktable(), highmem()).unwrap();
-	let (tcb, id) = ThreadControlBlock::new(
-		"<idle>".into(),
-		ttable,
-		crate::threading::thread_startup,
-		idle_loop,
-		0,
-	);
-
-	let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
 	
-	debug!("Create idle thread with {id:?}");
-
-	(id, thread, UnsafeCell::new(ptr))
-});
+		let ttable = TTableTy::new(&*ktable(), highmem()).unwrap();
+		let (tcb, id) = ThreadControlBlock::new(
+			"<idle>".into(),
+			ttable,
+			crate::threading::thread_startup,
+			idle_loop,
+			0,
+		);
+	
+		let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
+		
+		debug!("Create idle thread with {id:?}");
+	
+		(id, thread, UnsafeCell::new(ptr))
+	});
+}
 
 /// Adds a pending thread switch that will switch threads once all nested interrupts are handled.
 ///
@@ -109,7 +111,7 @@ pub fn yield_now() -> Option<WakeReason> {
 				Cannot have more than one `PointerView` alive as it is only materialised here, and immediately dropped
 				Reentrancy cannot occur here as interrupts are disabled due to the scheduler lock
 			 */
-			do_thread_switch(old_thread, unsafe { &mut *IDLE_THREAD.2.get() }.tcb_mut())
+			do_thread_switch(old_thread, unsafe { &mut *IDLE_THREAD().2.get() }.tcb_mut())
 		},
 		SchedulerSwitchState::SwitchFromIdle { new_thread } => {
 			// Switch from the idle task
@@ -122,7 +124,7 @@ pub fn yield_now() -> Option<WakeReason> {
 				In `post_switch_cleanup()` if the previous thread is the idle thread (as would be the case
 				here), the `ThreadPointer` is dropped and so we are back to only once copy
 			 */
-			do_thread_switch(unsafe { ptr::read(IDLE_THREAD.2.get()) }, new_thread)
+			do_thread_switch(unsafe { ptr::read(IDLE_THREAD().2.get()) }, new_thread)
 		}
 	}
 }
@@ -131,7 +133,7 @@ pub extern "C" fn post_switch_cleanup(mut previous_thread: ThreadPointer) {
 	let mut guard = unsafe { scheduler::local_scheduler().make_guard_unchecked() };
 	let tcb = previous_thread.tcb_mut();
 	trace!("[b] switch from `{:?}` to current, old blocked in state {:?}", tcb.thread_id, tcb.state);
-	if *tcb.thread_id != IDLE_THREAD.0 {
+	if *tcb.thread_id != IDLE_THREAD().0 {
 		// Don't enqueue idle thread into a scheduler
 		guard.switch_thread_post(previous_thread);
 	} else {

--- a/kernel/src/timing.rs
+++ b/kernel/src/timing.rs
@@ -126,11 +126,10 @@ pub(crate) fn tsc_to_nanos() -> (u128, NonZero<u128>) {
 	})
 }
 
-#[thread_local]
-pub static LOCAL_TIMER_QUEUE: TimerQueue = TimerQueue::new();
+percpu!(pub static LOCAL_TIMER_QUEUE: TimerQueue = TimerQueue::new());
 
 pub fn local_timer_queue_irq_handler() {
-	LOCAL_TIMER_QUEUE.handle_irq();
+	LOCAL_TIMER_QUEUE().handle_irq();
 }
 
 pub struct TimerQueue {


### PR DESCRIPTION
Closes #119

This replaces all uses of #[thread_local] with a new percpu!() macro, which uses custom inline assembly so LLVM can't optimise it out.
Additionally it uses GS as the TLS base register rather than FS, allowing the use of `swapgs` when switching between kernel and userspace.