### PR TITLE
Prepare for userspace

### DIFF
--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -443,7 +443,7 @@ fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
         }
     };
 
-    let symbol_map = symbol_map.map(|m| Box::leak(m.into_boxed_slice()));
+    let symbol_map = symbol_map.map(|m| &*Box::leak(m.into_boxed_slice()));
 
     info!("new stack at {:#x?}", stack);
 
@@ -562,7 +562,7 @@ fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
         if let Some(item) = last_item {
             kernel_mem_map.push(item);
         };
-        kernel_mem_map
+        Vec::leak(kernel_mem_map)
     };
 
     let kernel_entry = kernel.entrypoint();
@@ -595,7 +595,7 @@ fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
 
         },
         log: handoff::Logging {
-            symbol_map: symbol_map.map(NonNull::from)
+            symbol_map,
         },
         test: handoff::Testing {
             module_func: unsafe { mem::transmute(1usize) }

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -284,7 +284,7 @@ fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
         debug!("Loaded at base addr {:p}", image.info().0);
     }
 
-    let (mut kernel, symbol_map) = locate_kernel(&image_handle, &services);
+    let (mut kernel, symbol_map, test_program) = locate_kernel(&image_handle, &services);
 
 
     // =========== test code using kernel from efi part ===========
@@ -444,6 +444,7 @@ fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     };
 
     let symbol_map = symbol_map.map(|m| &*Box::leak(m.into_boxed_slice()));
+    let test_program = &*Box::leak(test_program.into_boxed_slice());
 
     info!("new stack at {:#x?}", stack);
 
@@ -601,7 +602,8 @@ fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
             module_func: unsafe { mem::transmute(1usize) }
         },
         tls: (Range(kernel_tls.0.start, kernel_tls.0.end), kernel_tls.1),
-        rsdp
+        rsdp,
+        init_exec: test_program,
     });
 
     let _ = system_table.exit_boot_services();
@@ -645,7 +647,7 @@ fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     }
 }
 
-fn locate_kernel(image_handle: &Handle, services: &BootServices) -> (Vec<u8>, Option<Vec<u8>>) {
+fn locate_kernel(image_handle: &Handle, services: &BootServices) -> (Vec<u8>, Option<Vec<u8>>, Vec<u8>) {
     // FIXME: this doesn't check which disk is being used so it'll happily load popcorn from any random disk
 
     let mut root_partition_handle: Option<Handle> = None;
@@ -671,6 +673,7 @@ fn locate_kernel(image_handle: &Handle, services: &BootServices) -> (Vec<u8>, Op
 
     // TODO: versioning
     let symbol_map = fs.read(Path::new(cstr16!(r"\kernel\kernel.map"))).ok();
+    let test_program = fs.read(Path::new(cstr16!(r"\user\init.exec"))).expect("Could not find `init`");
     let kernel_data = fs.read(Path::new(cstr16!(r"\kernel\kernel.exec"))).expect("Unable to find a bootable kernel");
 
     /*
@@ -681,7 +684,7 @@ fn locate_kernel(image_handle: &Handle, services: &BootServices) -> (Vec<u8>, Op
         unsafe { NonNull::new_unchecked(p) }
     });
      */
-    (kernel_data, symbol_map)
+    (kernel_data, symbol_map, test_program)
 }
 
 #[panic_handler]

--- a/bootloader/src/paging.rs
+++ b/bootloader/src/paging.rs
@@ -243,7 +243,7 @@ impl TableEntryFlags {
 	pub fn from_reason(reason: u16) -> Self {
 		let reason = u64::from(reason);
 		let low = (reason & 7) << 9;
-		let high = (reason & 0x7ff8) << (52 - 3);
+		let high = (reason & 0x3ff8) << (52 - 3);
 		Self::from_bits_retain(low | high)
 	}
 }

--- a/elf/src/dynamic_table.rs
+++ b/elf/src/dynamic_table.rs
@@ -123,14 +123,22 @@ impl<'a> Iterator for DynamicTableIter<'a> {
 	}
 }
 
-impl<'a> super::File<'a> {
-	pub fn dynamic_table(&self) -> impl Iterator<Item = DynamicTableEntry> + '_ {
-		let Some(dynamic_segment) = self.segments().find(|segment| segment.segment_type == SegmentType::DYNAMIC) else {
-			panic!("can't find _DYNAMIC")
-		};
-
-		DynamicTableIter::new(self.index_data(dynamic_segment.file_location()))
-				.filter_map(Result::ok)
-				.map(|entry| unsafe { entry.relocate(self.base) })
-	}
+macro_rules! file_dyn_table {
+    ($ty:ident) => {
+		impl<'a> $ty <'a> {
+			pub fn dynamic_table(&self) -> impl Iterator<Item = DynamicTableEntry> + '_ {
+				let Some(dynamic_segment) = self.segments().find(|segment| segment.segment_type == SegmentType::DYNAMIC) else {
+					panic!("can't find _DYNAMIC")
+				};
+		
+				DynamicTableIter::new(self.index_data(dynamic_segment.file_location()))
+						.filter_map(Result::ok)
+						.map(|entry| unsafe { entry.relocate(self.base) })
+			}
+		}
+    };
 }
+
+use super::{File, FileMut};
+file_dyn_table!(File);
+file_dyn_table!(FileMut);

--- a/elf/src/lib.rs
+++ b/elf/src/lib.rs
@@ -18,86 +18,124 @@ pub mod relocation;
 pub mod dynamic_table;
 pub mod header;
 
-#[derive(Debug)]
-#[repr(C)]
-pub struct File<'a> {
-	/// Base address of the executable
-	/// Can be adjusted by calling [`File::relocate()`]
-	base: u64,
-	header: &'a FileHeader,
-	program_header: &'a [ProgramHeaderEntry64],
-	section_header: &'a [u8],
-	/// The contents of the executable (including all headers)
-	data: *mut [u8],
-	_phantom: PhantomData<&'a mut [u8]>
-}
-
 type Error = header::file::Error;
 
-impl<'a> File<'a> {
-	pub fn try_new(elf_data: &'a mut [u8]) -> Result<File<'a>, Error> {
-		let data_len = elf_data.len();
-		let data_ptr = elf_data as *mut [u8] as *mut u8;
-		let header = &elf_data[..size_of::<FileHeader>()];
-
-		FileHeader::try_new(header).map(|header| {
-			let program_header = {
-				let Range{ start, end } = header.program_header();
-				let count = (end - start) / header.program_header_entry_size();
-				unsafe {
-					// SAFETY:
-					// start is non-null since taken from a non-null data pointer
-					// alignment checked by assertion
-					// reference only aliases with immutable reference to data
-					let start = data_ptr.byte_add(start).cast::<ProgramHeaderEntry64>();
-					assert!(start.is_aligned());
-				    &*slice_from_raw_parts(start, count)
-				}
-			};
-
-			let section_header = {
-				let Range{ start, end } = header.section_header();
-				let count = (end - start) / header.section_header_entry_size();
-				unsafe {
-					// SAFETY:
-					// start is non-null since taken from a non-null data pointer
-					// alignment checked by assertion
-					// reference only aliases with immutable reference to data
-					let start = data_ptr.byte_add(start).cast::<u8>();
-					assert!(start.is_aligned());
-					&*slice_from_raw_parts(start, count)
-				}
-			};
-
-			File {
-				base: 0,
-				header,
-				program_header,
-				section_header,
-				data: slice_from_raw_parts_mut(data_ptr, data_len),
-				_phantom: PhantomData
-			}
-		})
-	}
-
-	pub fn segments(&self) -> impl Iterator<Item = ProgramHeaderEntry64> + '_ {
-		self.program_header.iter()
-				.map(|entry| {
-					ProgramHeaderEntry64 {
-						vaddr: entry.vaddr + self.base,
-						.. *entry
+macro_rules! file {
+	(@ref mut $ty:ty) => { &'a mut $ty };
+	(@ref const $ty:ty) => { &'a $ty };
+	(@slice mut $($arg:tt)*) => { slice_from_raw_parts_mut($($arg)*) };
+	(@slice const $($arg:tt)*) => { slice_from_raw_parts($($arg)*) };
+    ($ty:ident $m:tt) => {
+	    #[derive(Debug)]
+		#[repr(C)]
+		pub struct $ty<'a> {
+			/// Base address of the executable
+			/// Can be adjusted by calling [`File::relocate()`]
+			base: u64,
+			header: &'a FileHeader,
+			program_header: &'a [ProgramHeaderEntry64],
+			section_header: &'a [u8],
+			/// The contents of the executable (including all headers)
+			data: * $m [u8],
+			_phantom: PhantomData<file!(@ref $m [u8])>
+		}
+	    
+	    impl<'a> $ty<'a> {
+			pub fn try_new(elf_data: file!(@ref $m [u8])) -> Result< $ty <'a>, Error> {
+				let data_len = elf_data.len();
+				let data_ptr = elf_data.as_ptr();
+				let header = &elf_data[..size_of::<FileHeader>()];
+		
+				FileHeader::try_new(header).map(|header| {
+					let program_header = {
+						let Range{ start, end } = header.program_header();
+						let count = (end - start) / header.program_header_entry_size();
+						unsafe {
+							// SAFETY:
+							// start is non-null since taken from a non-null data pointer
+							// alignment checked by assertion
+							// reference only aliases with immutable reference to data
+							let start = data_ptr.byte_add(start).cast::<ProgramHeaderEntry64>();
+							assert!(start.is_aligned());
+						    &*slice_from_raw_parts(start, count)
+						}
+					};
+		
+					let section_header = {
+						let Range{ start, end } = header.section_header();
+						let count = (end - start) / header.section_header_entry_size();
+						unsafe {
+							// SAFETY:
+							// start is non-null since taken from a non-null data pointer
+							// alignment checked by assertion
+							// reference only aliases with immutable reference to data
+							let start = data_ptr.byte_add(start).cast::<u8>();
+							assert!(start.is_aligned());
+							&*slice_from_raw_parts(start, count)
+						}
+					};
+		
+					$ty {
+						base: 0,
+						header,
+						program_header,
+						section_header,
+						data: file!(@slice $m data_ptr as * $m _, data_len),
+						_phantom: PhantomData
 					}
 				})
-	}
-
-	fn index_data(&self, slice: FileLocation) -> &[u8] {
-		// SAFETY: self.data must be valid, and returning an immutable reference so fine to alias with self.{program,section}_header
-		unsafe {
-			&(*self.data)[slice.0]
+			}
+		
+			pub fn segments(&self) -> impl Iterator<Item = ProgramHeaderEntry64> + '_ {
+				self.program_header.iter()
+						.map(|entry| {
+							ProgramHeaderEntry64 {
+								vaddr: entry.vaddr + self.base,
+								.. *entry
+							}
+						})
+			}
+		
+			fn index_data(&self, slice: FileLocation) -> &[u8] {
+				// SAFETY: self.data must be valid, and returning an immutable reference so fine to alias with self.{program,section}_header
+				unsafe {
+					&(*self.data)[slice.0]
+				}
+			}
+		    
+		    fn segment_for_address(&self, addr: ExecutableAddressRelocated) -> Option<ProgramHeaderEntry64> {
+				self.segments().find(|segment| segment.memory_location().contains(&addr.0))
+			}
+		
+			pub fn data_at_address(&self, addr: ExecutableAddressRelocated) -> Option<*const u8> {
+				let segment = self.segment_for_address(addr)?;
+				Some(unsafe {
+					self[segment.file_location()].as_ptr().byte_add(usize::try_from(addr.0 - segment.vaddr).unwrap())
+				})
+			}
+		    
+		    fn data_at_unrel_address(&self, addr: ExecutableAddressUnrelocated) -> Option<*const u8> { self.data_at_address(ExecutableAddressRelocated(addr.0 + self.base)) }
+			
+			pub fn entrypoint(&self) -> usize {
+				self.header.entry_point()
+			}
 		}
-	}
+	    
+	    impl<'a> Index<FileLocation> for $ty <'a> {
+			type Output = [u8];
+		
+			fn index(&self, index: FileLocation) -> &Self::Output {
+				self.index_data(index)
+			}
+		}
+    };
+}
 
-	fn index_data_mut(&mut self, slice: FileLocation) -> &mut [u8] {
+file!(File const);
+file!(FileMut mut);
+
+impl<'a> FileMut<'a> {
+		fn index_data_mut(&mut self, slice: FileLocation) -> &mut [u8] {
 		fn ranges_overlap(a: Range<usize>, b: Range<usize>) -> bool {
 			!(a.start >= b.end || b.start >= a.end)
 		}
@@ -115,17 +153,6 @@ impl<'a> File<'a> {
 		}
 	}
 
-	fn segment_for_address(&self, addr: ExecutableAddressRelocated) -> Option<ProgramHeaderEntry64> {
-		self.segments().find(|segment| segment.memory_location().contains(&addr.0))
-	}
-
-	pub fn data_at_address(&self, addr: ExecutableAddressRelocated) -> Option<*const u8> {
-		let segment = self.segment_for_address(addr)?;
-		Some(unsafe {
-			self[segment.file_location()].as_ptr().byte_add(usize::try_from(addr.0 - segment.vaddr).unwrap())
-		})
-	}
-
 	pub fn data_at_address_mut(&mut self, addr: ExecutableAddressRelocated) -> Option<*mut u8> {
 		let segment = self.segment_for_address(addr)?;
 		Some(unsafe {
@@ -133,23 +160,10 @@ impl<'a> File<'a> {
 		})
 	}
 
-	fn data_at_unrel_address(&self, addr: ExecutableAddressUnrelocated) -> Option<*const u8> { self.data_at_address(ExecutableAddressRelocated(addr.0 + self.base)) }
 	fn data_at_unrel_address_mut(&mut self, addr: ExecutableAddressUnrelocated) -> Option<*mut u8> { self.data_at_address_mut(ExecutableAddressRelocated(addr.0 + self.base)) }
-
-	pub fn entrypoint(&self) -> usize {
-		self.header.entry_point()
-	}
 }
 
-impl<'a> Index<FileLocation> for File<'a> {
-	type Output = [u8];
-
-	fn index(&self, index: FileLocation) -> &Self::Output {
-		self.index_data(index)
-	}
-}
-
-impl<'a> IndexMut<FileLocation> for File<'a> {
+impl<'a> IndexMut<FileLocation> for FileMut<'a> {
 	fn index_mut(&mut self, index: FileLocation) -> &mut Self::Output {
 		self.index_data_mut(index)
 	}

--- a/elf/src/relocation.rs
+++ b/elf/src/relocation.rs
@@ -59,85 +59,96 @@ pub struct RelocationWithAddend {
 	pub addend: i64
 }
 
-impl<'a> super::File<'a> {
-	pub fn relocations(&self) -> impl Iterator<Item = RelocationTableEntry> + '_ {
-		let rel_table_addresses = self.dynamic_table().filter_map(|entry| match entry {
-			DynamicTableEntry::RelTableAddress(addr) => Some(addr),
-			_ => None
-		});
+macro_rules! reloc {
+    ($ty:ident) => {
+	    impl<'a> $ty <'a> {
+			pub fn relocations(&self) -> impl Iterator<Item = RelocationTableEntry> + '_ {
+				let rel_table_addresses = self.dynamic_table().filter_map(|entry| match entry {
+					DynamicTableEntry::RelTableAddress(addr) => Some(addr),
+					_ => None
+				});
+		
+				let rel_table_lengths = self.dynamic_table().filter_map(|entry| match entry {
+					DynamicTableEntry::RelTableSize(len) => Some(len),
+					_ => None
+				});
+		
+				let rel_tables = zip(rel_table_addresses, rel_table_lengths);
+				let rel_tables = rel_tables.map(|(start, length)| {
+					let rel_table_ptr = self.data_at_address(start).unwrap();
+					let slice = unsafe { &*slice_from_raw_parts(rel_table_ptr.cast::<Relocation>(), usize::try_from(length).unwrap() / mem::size_of::<Relocation>()) };
+					slice.iter()
+					     .map(|entry| RelocationTableEntry::Rel(*entry))
+				});
+		
+				let rela_table_addresses = self.dynamic_table().filter_map(|entry| match entry {
+					DynamicTableEntry::RelaTableAddress(addr) => Some(addr),
+					_ => None
+				});
+		
+				let rela_table_lengths = self.dynamic_table().filter_map(|entry| match entry {
+					DynamicTableEntry::RelaTableSize(len) => Some(len),
+					_ => None
+				});
+		
+				let rela_tables = zip(rela_table_addresses, rela_table_lengths);
+				let rela_tables = rela_tables.map(|(start, length)| {
+					let rela_table_ptr = self.data_at_address(start).unwrap();
+					let slice = unsafe { &*slice_from_raw_parts(rela_table_ptr.cast::<RelocationWithAddend>(), usize::try_from(length).unwrap() / mem::size_of::<RelocationWithAddend>()) };
+					slice.iter()
+					     .map(|entry| RelocationTableEntry::Rela(*entry))
+				});
+		
+				rel_tables.flatten().chain(rela_tables.flatten())
+			}
+		
+			pub fn jumptable_relocations(&self) -> Option<impl Iterator<Item = RelocationTableEntry> +'_> {
+				let table_address = self.dynamic_table().find_map(|entry| match entry {
+					DynamicTableEntry::JumptableRelocations(addr) => Some(addr),
+					_ => None
+				})?;
+		
+				let table_length = self.dynamic_table().find_map(|entry| match entry {
+					DynamicTableEntry::PltRelocationTableSize(len) => Some(len),
+					_ => None
+				})?;
+		
+				let table_entry_type = self.dynamic_table().find_map(|entry| match entry {
+					DynamicTableEntry::PltRelType(7) => Some(RelocationEntryType::Rela),
+					DynamicTableEntry::PltRelType(17) => Some(RelocationEntryType::Rel),
+					_ => None
+				})?;
+		
+				let table_pointer = self.data_at_address(table_address).unwrap();
+		
+				let a = if table_entry_type == RelocationEntryType::Rel {
+					let slice = unsafe { &*slice_from_raw_parts(
+						table_pointer.cast::<Relocation>(),
+						usize::try_from(table_length).unwrap() / size_of::<Relocation>()
+					) };
+					Some(slice.iter().map(|entry| RelocationTableEntry::Rel(*entry)))
+				} else { None };
+		
+				let b = if table_entry_type == RelocationEntryType::Rela {
+					let slice = unsafe { &*slice_from_raw_parts(
+						table_pointer.cast::<RelocationWithAddend>(),
+						usize::try_from(table_length).unwrap() / size_of::<RelocationWithAddend>()
+					) };
+					Some(slice.iter().map(|entry| RelocationTableEntry::Rela(*entry)))
+				} else { None };
+		
+				Some(a.into_iter().flatten().chain(b.into_iter().flatten()))
+			}
+		}
+    };
+}
 
-		let rel_table_lengths = self.dynamic_table().filter_map(|entry| match entry {
-			DynamicTableEntry::RelTableSize(len) => Some(len),
-			_ => None
-		});
+use super::{File, FileMut};
 
-		let rel_tables = zip(rel_table_addresses, rel_table_lengths);
-		let rel_tables = rel_tables.map(|(start, length)| {
-			let rel_table_ptr = self.data_at_address(start).unwrap();
-			let slice = unsafe { &*slice_from_raw_parts(rel_table_ptr.cast::<Relocation>(), usize::try_from(length).unwrap() / mem::size_of::<Relocation>()) };
-			slice.iter()
-			     .map(|entry| RelocationTableEntry::Rel(*entry))
-		});
+reloc!(File);
+reloc!(FileMut);
 
-		let rela_table_addresses = self.dynamic_table().filter_map(|entry| match entry {
-			DynamicTableEntry::RelaTableAddress(addr) => Some(addr),
-			_ => None
-		});
-
-		let rela_table_lengths = self.dynamic_table().filter_map(|entry| match entry {
-			DynamicTableEntry::RelaTableSize(len) => Some(len),
-			_ => None
-		});
-
-		let rela_tables = zip(rela_table_addresses, rela_table_lengths);
-		let rela_tables = rela_tables.map(|(start, length)| {
-			let rela_table_ptr = self.data_at_address(start).unwrap();
-			let slice = unsafe { &*slice_from_raw_parts(rela_table_ptr.cast::<RelocationWithAddend>(), usize::try_from(length).unwrap() / mem::size_of::<RelocationWithAddend>()) };
-			slice.iter()
-			     .map(|entry| RelocationTableEntry::Rela(*entry))
-		});
-
-		rel_tables.flatten().chain(rela_tables.flatten())
-	}
-
-	pub fn jumptable_relocations(&self) -> Option<impl Iterator<Item = RelocationTableEntry> +'_> {
-		let table_address = self.dynamic_table().find_map(|entry| match entry {
-			DynamicTableEntry::JumptableRelocations(addr) => Some(addr),
-			_ => None
-		})?;
-
-		let table_length = self.dynamic_table().find_map(|entry| match entry {
-			DynamicTableEntry::PltRelocationTableSize(len) => Some(len),
-			_ => None
-		})?;
-
-		let table_entry_type = self.dynamic_table().find_map(|entry| match entry {
-			DynamicTableEntry::PltRelType(7) => Some(RelocationEntryType::Rela),
-			DynamicTableEntry::PltRelType(17) => Some(RelocationEntryType::Rel),
-			_ => None
-		})?;
-
-		let table_pointer = self.data_at_address(table_address).unwrap();
-
-		let a = if table_entry_type == RelocationEntryType::Rel {
-			let slice = unsafe { &*slice_from_raw_parts(
-				table_pointer.cast::<Relocation>(),
-				usize::try_from(table_length).unwrap() / size_of::<Relocation>()
-			) };
-			Some(slice.iter().map(|entry| RelocationTableEntry::Rel(*entry)))
-		} else { None };
-
-		let b = if table_entry_type == RelocationEntryType::Rela {
-			let slice = unsafe { &*slice_from_raw_parts(
-				table_pointer.cast::<RelocationWithAddend>(),
-				usize::try_from(table_length).unwrap() / size_of::<RelocationWithAddend>()
-			) };
-			Some(slice.iter().map(|entry| RelocationTableEntry::Rela(*entry)))
-		} else { None };
-
-		Some(a.into_iter().flatten().chain(b.into_iter().flatten()))
-	}
-
+impl<'a> FileMut<'a> {
 	pub fn relocate(&mut self, base: u64) {
 		let relocs = self.relocations().collect::<alloc::vec::Vec<_>>();
 		for reloc in relocs {

--- a/elf/src/string_table.rs
+++ b/elf/src/string_table.rs
@@ -23,23 +23,31 @@ impl From<u32> for StringIndex {
 	}
 }
 
-impl<'a> super::File<'a> {
-	pub fn dynamic_string_table(&self) -> Option<StringTable<'_>> {
-		let string_table_addr = self.dynamic_table().find_map(|entry| match entry {
-			DynamicTableEntry::StringTable(addr) => Some(addr),
-			_ => None
-		})?;
-
-		let string_table_length = self.dynamic_table().find_map(|entry| match entry {
-			DynamicTableEntry::StringTableSize(len) => Some(len),
-			_ => None
-		})?;
-
-		let string_table = {
-			let string_table_ptr = self.data_at_address(string_table_addr).unwrap();
-			unsafe { &*slice_from_raw_parts(string_table_ptr.cast::<ffi::c_char>(), usize::try_from(string_table_length).unwrap()) }
-		};
-
-		Some(StringTable(string_table))
-	}
+macro_rules! string_tab {
+    ($ty:ident) => {
+		impl<'a> $ty <'a> {
+			pub fn dynamic_string_table(&self) -> Option<StringTable<'_>> {
+				let string_table_addr = self.dynamic_table().find_map(|entry| match entry {
+					DynamicTableEntry::StringTable(addr) => Some(addr),
+					_ => None
+				})?;
+		
+				let string_table_length = self.dynamic_table().find_map(|entry| match entry {
+					DynamicTableEntry::StringTableSize(len) => Some(len),
+					_ => None
+				})?;
+		
+				let string_table = {
+					let string_table_ptr = self.data_at_address(string_table_addr).unwrap();
+					unsafe { &*slice_from_raw_parts(string_table_ptr.cast::<ffi::c_char>(), usize::try_from(string_table_length).unwrap()) }
+				};
+		
+				Some(StringTable(string_table))
+			}
+		}
+    };
 }
+
+use super::{File, FileMut};
+string_tab!(File);
+string_tab!(FileMut);

--- a/elf/src/symbol_table.rs
+++ b/elf/src/symbol_table.rs
@@ -33,49 +33,57 @@ impl SymbolInfo {
 	fn get_type(&self) -> u8 { self.0 >> 4 }
 }
 
-impl<'a> super::File<'a> {
-	pub fn dynamic_symbol_table(&self) -> Option<&[SymbolTableEntry]> {
-		let symbol_table_addr = self.dynamic_table().find_map(|entry| match entry {
-			DynamicTableEntry::SymbolTable(addr) => Some(addr),
-			_ => None
-		})?;
-
-		let hash_table_addr = self.dynamic_table().find_map(|entry| match entry {
-			DynamicTableEntry::HashTable(addr) => Some(addr),
-			_ => None
-		})?;
-
-		let hashtable_length = unsafe { *self.data_at_address(hash_table_addr).unwrap().cast::<u32>().offset(1) };
-		let symbol_table = {
-			let symbol_table_ptr = self.data_at_address(symbol_table_addr).unwrap();
-			unsafe { &*slice_from_raw_parts(symbol_table_ptr.cast::<SymbolTableEntry>(), usize::try_from(hashtable_length).unwrap()) }
-		};
-
-		Some(symbol_table)
-	}
-
-	pub fn exported_symbols(&self) -> SymbolMap<'_> {
-		let mut map = SymbolMap::new();
-
-		if let Some(symbol_table) = self.dynamic_symbol_table() {
-			let string_table = self.dynamic_string_table().unwrap();
-
-			for symbol in symbol_table {
-				if symbol.section_table_index != 0 && !symbol.info.is_local() {
-					let name = string_table.get_string(symbol.name.unwrap());
-					debug!("{name:?} : {symbol:?}");
-					// SAFETY: using correct base for this file
-					let symbol =
-							if symbol.info.is_weak() { ExportedSymbol::new_weak(unsafe { symbol.value.relocate(self.base) }, symbol.size) }
-							else { ExportedSymbol::new_strong(unsafe { symbol.value.relocate(self.base) }, symbol.size) };
-					map.insert(name, symbol);
+macro_rules! sym {
+    ($ty:ident) => {
+		impl<'a> $ty <'a> {
+			pub fn dynamic_symbol_table(&self) -> Option<&[SymbolTableEntry]> {
+				let symbol_table_addr = self.dynamic_table().find_map(|entry| match entry {
+					DynamicTableEntry::SymbolTable(addr) => Some(addr),
+					_ => None
+				})?;
+		
+				let hash_table_addr = self.dynamic_table().find_map(|entry| match entry {
+					DynamicTableEntry::HashTable(addr) => Some(addr),
+					_ => None
+				})?;
+		
+				let hashtable_length = unsafe { *self.data_at_address(hash_table_addr).unwrap().cast::<u32>().offset(1) };
+				let symbol_table = {
+					let symbol_table_ptr = self.data_at_address(symbol_table_addr).unwrap();
+					unsafe { &*slice_from_raw_parts(symbol_table_ptr.cast::<SymbolTableEntry>(), usize::try_from(hashtable_length).unwrap()) }
+				};
+		
+				Some(symbol_table)
+			}
+		
+			pub fn exported_symbols(&self) -> SymbolMap<'_> {
+				let mut map = SymbolMap::new();
+		
+				if let Some(symbol_table) = self.dynamic_symbol_table() {
+					let string_table = self.dynamic_string_table().unwrap();
+		
+					for symbol in symbol_table {
+						if symbol.section_table_index != 0 && !symbol.info.is_local() {
+							let name = string_table.get_string(symbol.name.unwrap());
+							debug!("{name:?} : {symbol:?}");
+							// SAFETY: using correct base for this file
+							let symbol =
+									if symbol.info.is_weak() { ExportedSymbol::new_weak(unsafe { symbol.value.relocate(self.base) }, symbol.size) }
+									else { ExportedSymbol::new_strong(unsafe { symbol.value.relocate(self.base) }, symbol.size) };
+							map.insert(name, symbol);
+						}
+					}
 				}
+		
+				map
 			}
 		}
-
-		map
-	}
+	};
 }
+
+use super::{FileMut, File};
+sym!(File);
+sym!(FileMut);
 
 #[derive(Debug, Clone)]
 pub struct SymbolMap<'a>(HashMap<&'a CStr, ExportedSymbol>);

--- a/kernel/src/hal/arch/amd64/interrupts.asm
+++ b/kernel/src/hal/arch/amd64/interrupts.asm
@@ -5,6 +5,12 @@ amd64_global_irq_handler:
     .cfi_def_cfa rsp, 56 # CFA = rsp + 7*8 (top of interrupt frame)
     .cfi_offset rip, -40 # %RA = CFA - 5*8 (offset of rip in stack frame)
     .cfi_offset rsp, -16 # %RSP = CFA - 2*8 (offset of rsp in stack frame)
+
+    cmp byte ptr [rsp + 24], 0x8 # check if CS == kernel CS (24 because CS is at 8, and then we also have error code + vector)
+    je 2f
+    swapgs # if not, we come from userspace, so swap GS and kernel GS
+    2:
+
     push rax
     .cfi_def_cfa_offset 64
     .cfi_offset rax, -64
@@ -32,7 +38,6 @@ amd64_global_irq_handler:
     push r11
     .cfi_def_cfa_offset 128
     .cfi_offset r11, -128
-    # TODO: `swapgs`
     mov rdi, rsp
     sti
     call amd64_handler2
@@ -65,6 +70,12 @@ amd64_global_irq_handler:
     .cfi_same_value rax
     add rsp, 16
     .cfi_def_cfa_offset 40
+
+    cmp byte ptr [rsp + 8], 0x8 # check if CS == kernel CS (already popped vector num and error code so only +8)
+    je 3f
+    swapgs # if not, we come from userspace, so swap GS and kernel GS
+    3:
+
     iretq
     .cfi_endproc
     .size amd64_global_irq_handler, .-amd64_global_irq_handler

--- a/kernel/src/hal/arch/amd64/interrupts.rs
+++ b/kernel/src/hal/arch/amd64/interrupts.rs
@@ -363,7 +363,7 @@ pub unsafe extern "C-unwind" fn amd64_syscall_handler() {
 		"mov r12, rcx", // save rcx (for sysret)
 		"mov r13, r11", // save r11 (for sysret)
 		
-		"mov rsp, gs:[-8]", // load kernel stack from [TLS - 8] - see hal::switch_thread for notes
+		"mov rsp, gs:[{rsp0_offset}]", // load kernel stack from [TLS - 8] - see hal::switch_thread for notes
 		"sti", // can take interrupts now that stack is sorted
 			   // todo: fix for NMI stuff
 		
@@ -385,6 +385,7 @@ pub unsafe extern "C-unwind" fn amd64_syscall_handler() {
 		"swapgs",
 		"sysretq",
 		sym crate::syscall_handler,
+		rsp0_offset = const core::mem::offset_of!(crate::percpu::Percpu, kernel_stack_top),
 	);
 }
 

--- a/kernel/src/hal/arch/amd64/interrupts.rs
+++ b/kernel/src/hal/arch/amd64/interrupts.rs
@@ -355,7 +355,7 @@ extern "C-unwind" fn amd64_handler2(data: &mut IrqData) {
 }
 
 #[naked]
-unsafe extern "C-unwind" fn amd64_syscall_handler() {
+pub unsafe extern "C-unwind" fn amd64_syscall_handler() {
 	naked_asm!("ud2");
 }
 

--- a/kernel/src/hal/arch/amd64/interrupts.rs
+++ b/kernel/src/hal/arch/amd64/interrupts.rs
@@ -356,7 +356,36 @@ extern "C-unwind" fn amd64_handler2(data: &mut IrqData) {
 
 #[naked]
 pub unsafe extern "C-unwind" fn amd64_syscall_handler() {
-	naked_asm!("ud2");
+	naked_asm!(
+		"swapgs",
+		
+		"mov rbx, rsp", // save userspace stack pointer
+		"mov r12, rcx", // save rcx (for sysret)
+		"mov r13, r11", // save r11 (for sysret)
+		
+		"mov rsp, gs:[-8]", // load kernel stack from [TLS - 8] - see hal::switch_thread for notes
+		"sti", // can take interrupts now that stack is sorted
+			   // todo: fix for NMI stuff
+		
+		"mov r9, rdx",
+		"mov rcx, rdi",
+		"mov r8, rsi",
+		"movq rdi, xmm0",
+		"punpckhqdq xmm0, xmm0", // broadcast the high half of xmm0 to both halves
+		"movq rsi, xmm0",
+		"mov rdx, rax",
+		
+		"call {}", // extern C function so return val already in rax
+		
+		"cli",
+		"mov r11, r13", // restore registers to userspace state
+		"mov rcx, r12",
+		"mov rsp, rbx",
+		
+		"swapgs",
+		"sysretq",
+		sym crate::syscall_handler,
+	);
 }
 
 global_asm!(include_str!("interrupts.asm"), options(raw));

--- a/kernel/src/hal/arch/amd64/interrupts.rs
+++ b/kernel/src/hal/arch/amd64/interrupts.rs
@@ -270,18 +270,23 @@ extern "C-unwind" fn amd64_handler2(data: &mut IrqData) {
 		gs_kernel: u64::MAX,
 	};
 	
+	let user_mode = reg_dump.stack_frame.cs > 0x10;
+	
 	let mut exception_payload = match reg_dump.stack_frame.num as u8 {
 		0 | 16 | 19 => Exception {
 			ty: Ty::FloatingPoint,
 			registers: &mut reg_dump,
+			user_mode,
 		},
 		1 | 3 => Exception {
 			ty: Ty::Debug(DebugTy::Breakpoint),
 			registers: &mut reg_dump,
+			user_mode,
 		},
 		6 => Exception {
 			ty: Ty::IllegalInstruction,
 			registers: &mut reg_dump,
+			user_mode,
 		},
 		14 => {
 			let cr2: usize;
@@ -289,19 +294,23 @@ extern "C-unwind" fn amd64_handler2(data: &mut IrqData) {
 			Exception {
 				ty: Ty::PageFault(PageFault { access_addr: cr2, meta: reg_dump.stack_frame.error.try_into().unwrap() }),
 				registers: &mut reg_dump,
+				user_mode,
 			}
 		},
 		7 | 17 => Exception {
 			ty: Ty::BusFault,
 			registers: &mut reg_dump,
+			user_mode,
 		},
 		2 => Exception {
 			ty: Ty::Nmi,
 			registers: &mut reg_dump,
+			user_mode,
 		},
 		8 => Exception {
 			ty: Ty::Panic,
 			registers: &mut reg_dump,
+			user_mode,
 		},
 		e @ (4 | 5 | 9..= 13 | 15 | 18 | 21..=27 | 31) => {
 			let reason = match e {
@@ -319,6 +328,7 @@ extern "C-unwind" fn amd64_handler2(data: &mut IrqData) {
 			Exception {
 				ty: Ty::Generic(reason),
 				registers: &mut reg_dump,
+				user_mode,
 			}
 		},
 		e @ (20 | 28..=30) => {
@@ -332,6 +342,7 @@ extern "C-unwind" fn amd64_handler2(data: &mut IrqData) {
 			Exception {
 				ty: Ty::Unknown(reason),
 				registers: &mut reg_dump,
+				user_mode,
 			}
 		},
 		e @ 32..48 => {

--- a/kernel/src/hal/arch/amd64/linker.ld
+++ b/kernel/src/hal/arch/amd64/linker.ld
@@ -9,7 +9,6 @@ PHDRS {
     dynamic PT_DYNAMIC ;
     gnu_eh_frame 0x6474E550 FLAGS(0x4) ;
     lazy PT_LOAD FLAGS(0x20006) ;
-    percpu PT_TLS FLAGS(0x406) ;
 }
 
 SECTIONS {
@@ -131,15 +130,6 @@ SECTIONS {
 	{
 	    *(.dynamic .dynamic.*)
 	} :data :dynamic
-
-    . = ALIGN(4K);
-	.percpu :
-	{
-	    __percpu_start = .;
-	    *(.percpu)
-	    *(SORT_BY_NAME(.percpu.*))
-	    __percpu_end = .;
-	} :percpu
 
 	. = ALIGN(4K);
 	PROVIDE(__popcorn_vmem_bootstrap_start = .);

--- a/kernel/src/hal/arch/amd64/linker.ld
+++ b/kernel/src/hal/arch/amd64/linker.ld
@@ -136,7 +136,8 @@ SECTIONS {
 	.percpu :
 	{
 	    __percpu_start = .;
-	    *(.percpu .percpu.*)
+	    *(.percpu)
+	    *(SORT_BY_NAME(.percpu.*))
 	    __percpu_end = .;
 	} :percpu
 

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -109,7 +109,11 @@ unsafe impl Hal for Amd64Hal {
 	}
 
 	unsafe fn load_tls(ptr: *mut u8) {
-		msr::wrmsr(msr::GSBase, ptr.addr() as _);
+		msr::wrmsr(msr::GS_BASE, ptr.addr() as _);
+	}
+
+	unsafe fn load_user_tls(ptr: *mut u8) {
+		msr::wrmsr(msr::KERNEL_GS_BASE, ptr.addr() as _);
 	}
 
 	unsafe fn construct_tables() -> (Self::KTableTy, Self::TTableTy) {
@@ -299,7 +303,8 @@ pub(super) mod msr {
 	pub const LSTAR: ModelSpecificRegister = ModelSpecificRegister(0xC0000082);
 	pub const CSTAR: ModelSpecificRegister = ModelSpecificRegister(0xC0000083);
 	pub const SFMASK: ModelSpecificRegister = ModelSpecificRegister(0xC0000084);
-	pub const GSBase: ModelSpecificRegister = ModelSpecificRegister(0xc0000101);
+	pub const GS_BASE: ModelSpecificRegister = ModelSpecificRegister(0xC0000101);
+	pub const KERNEL_GS_BASE: ModelSpecificRegister = ModelSpecificRegister(0xC0000102);
 
 	// fixme: is this always safe?
 	pub fn rdmsr(msr: ModelSpecificRegister) -> u64 {

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -3,8 +3,9 @@ use core::arch::{asm, naked_asm};
 use core::fmt::{Debug, Formatter};
 use core::mem::{MaybeUninit, offset_of};
 use core::num::NonZero;
+use core::sync::atomic::{AtomicUsize, Ordering};
 use kernel_api::memory::mapping::Stack;
-use kernel_api::memory::VirtualAddress;
+use kernel_api::memory::{Frame, VirtualAddress};
 use crate::hal::{ContextSwitchPreserve, IpiTarget};
 use crate::hal::{Hal, SaveStateTr, ThreadControlBlock};
 use crate::hal::arch::amd64::interrupts::handler::InterruptStackFrame;
@@ -121,10 +122,14 @@ unsafe impl Hal for Amd64Hal {
 	}
 	
 	unsafe extern "C" fn switch_thread(from: &mut PointerView, to: &mut PointerView, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve {
+		// used by syscall entry function which assumes it's at the end of TLS block, so force it to be .percpu.z_...
+		percpu!(static RSP0: AtomicUsize => "z_RSP0" = AtomicUsize::new(0));
+		
 		// currently in kernel mode so even if we get an interrupt on the new TSS.privilege_stack_table[0] value
 		// the CPU won't pay attention to it
-		tss::TSS.get().expect("TSS should be initialised")
+		let ptr = tss::TSS.get().expect("TSS should be initialised")
 				.set_rsp0(to.kernel_stack.virtual_end().end().align_down());
+		RSP0().store(to.kernel_stack.virtual_end().end().addr, Ordering::Relaxed);
 		
 		return inner(from.save_state, to.save_state, preserve);
 		

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -61,6 +61,20 @@ unsafe impl Hal for Amd64Hal {
 		gdt.load();
 		gdt.load_tss();
 
+		msr::wrmsr(
+			msr::STAR,
+			((24 | 0b11) << 48) | (8 << 48),
+		);
+		msr::wrmsr(
+			msr::LSTAR,
+			interrupts::amd64_syscall_handler as u64,
+		);
+		msr::wrmsr(
+			msr::SFMASK,
+			0xED5, // IF - disabled
+			       // OF, DF, SF, ZF, AF, PF, CF = 0 as required by SysV
+		);
+
 		interrupts::init_idt();
 		pic::init();
 

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -100,63 +100,70 @@ unsafe impl Hal for Amd64Hal {
 	unsafe fn construct_tables() -> (Self::KTableTy, Self::TTableTy) {
 		paging2::construct_tables()
 	}
-
-	#[naked]
-	unsafe extern "C" fn switch_thread(from: &PointerView, to: &PointerView, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve {
-		// rdi: from
-		// rsi: to
-		// rdx: preserve.0 -> rax
-		// rcx: preserve.1 -> rdx
-		naked_asm!(
-			"mov rdi, [rdi + {save_state_ptr_offset}]", // load pointer to `from` save-state into `rdi`
-			"mov rsi, [rsi + {save_state_ptr_offset}]", // load pointer to `to` save-state into `rsi`
-
-			"mov [rdi + {rbx_offset}], rbx",
-			"mov [rdi + {rsp_offset}], rsp",
-			"mov [rdi + {rbp_offset}], rbp",
-			"mov [rdi + {r12_offset}], r12",
-			"mov [rdi + {r13_offset}], r13",
-			"mov [rdi + {r14_offset}], r14",
-			"mov [rdi + {r15_offset}], r15",
-			"pushf",
-			"pop rbx",
-			"mov [rdi + {rflags_offset}], rbx",
-
-			//todo: "mov r12, [rsi + {pml4_offset}]",
-			//"mov r13, cr3",
-			//"cmp r12, r13",
-			//"je 2f",
-			//"mov cr3, r12",
-			//"2:",
-
-			// todo: adjust RSP0 in TSS
-			"mov rbx, [rdi + {rflags_offset}]",
-			"push rbx",
-			"popf",
-			"mov rbx, [rsi + {rbx_offset}]",
-			"mov rsp, [rsi + {rsp_offset}]",
-			"mov rbp, [rsi + {rbp_offset}]",
-			"mov r12, [rsi + {r12_offset}]",
-			"mov r13, [rsi + {r13_offset}]",
-			"mov r14, [rsi + {r14_offset}]",
-			"mov r15, [rsi + {r15_offset}]",
-
-			"mov rax, rdx",
-			"mov rdx, rcx",
-
-			"ret",
-
-			save_state_ptr_offset = const offset_of!(PointerView, save_state),
-			rbx_offset = const offset_of!(Amd64SaveState, rbx),
-			rsp_offset = const offset_of!(Amd64SaveState, rsp),
-			rbp_offset = const offset_of!(Amd64SaveState, rbp),
-			r12_offset = const offset_of!(Amd64SaveState, r12),
-			r13_offset = const offset_of!(Amd64SaveState, r13),
-			r14_offset = const offset_of!(Amd64SaveState, r14),
-			r15_offset = const offset_of!(Amd64SaveState, r15),
-			rflags_offset = const offset_of!(Amd64SaveState, rflags),
-			//pml4_offset = const offset_of!(PointerView, ttable.pml4),
-		);
+	
+	unsafe extern "C" fn switch_thread(from: &mut PointerView, to: &mut PointerView, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve {
+		// currently in kernel mode so even if we get an interrupt on the new TSS.privilege_stack_table[0] value
+		// the CPU won't pay attention to it
+		tss::TSS.get().expect("TSS should be initialised")
+				.set_rsp0(to.kernel_stack.virtual_end().end().align_down());
+		
+		return inner(from.save_state, to.save_state, preserve);
+		
+		#[naked]
+		unsafe extern "C" fn inner(from: &mut Amd64SaveState, to: &Amd64SaveState, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve {
+			// rdi: from
+			// rsi: to
+			// rdx: preserve.0 -> rax
+			// rcx: preserve.1 -> rdx
+			naked_asm!(
+				// save all registers into `from` Amd64SaveState struct
+				"mov [rdi + {rbx_offset}], rbx",
+				"mov [rdi + {rsp_offset}], rsp",
+				"mov [rdi + {rbp_offset}], rbp",
+				"mov [rdi + {r12_offset}], r12",
+				"mov [rdi + {r13_offset}], r13",
+				"mov [rdi + {r14_offset}], r14",
+				"mov [rdi + {r15_offset}], r15",
+				"pushf",
+				"pop rbx",
+				"mov [rdi + {rflags_offset}], rbx",
+	
+				//todo: "mov r12, [rsi + {pml4_offset}]",
+				//"mov r13, cr3",
+				//"cmp r12, r13",
+				//"je 2f",
+				//"mov cr3, r12",
+				//"2:",
+	
+				// restore all registers from `to` Amd64SaveState struct
+				"mov rbx, [rdi + {rflags_offset}]",
+				"push rbx",
+				"popf",
+				"mov rbx, [rsi + {rbx_offset}]",
+				"mov rsp, [rsi + {rsp_offset}]",
+				"mov rbp, [rsi + {rbp_offset}]",
+				"mov r12, [rsi + {r12_offset}]",
+				"mov r13, [rsi + {r13_offset}]",
+				"mov r14, [rsi + {r14_offset}]",
+				"mov r15, [rsi + {r15_offset}]",
+				
+				// move data from `ContextSwitchPreserve` into return registers
+				"mov rax, rdx",
+				"mov rdx, rcx",
+	
+				"ret",
+	
+				rbx_offset = const offset_of!(Amd64SaveState, rbx),
+				rsp_offset = const offset_of!(Amd64SaveState, rsp),
+				rbp_offset = const offset_of!(Amd64SaveState, rbp),
+				r12_offset = const offset_of!(Amd64SaveState, r12),
+				r13_offset = const offset_of!(Amd64SaveState, r13),
+				r14_offset = const offset_of!(Amd64SaveState, r14),
+				r15_offset = const offset_of!(Amd64SaveState, r15),
+				rflags_offset = const offset_of!(Amd64SaveState, rflags),
+				//pml4_offset = const offset_of!(PointerView, ttable.pml4),
+			);
+		}
 	}
 
 	fn send_ipi(target: IpiTarget) -> Result<(), ()> {

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -122,14 +122,11 @@ unsafe impl Hal for Amd64Hal {
 	}
 	
 	unsafe extern "C" fn switch_thread(from: &mut PointerView, to: &mut PointerView, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve {
-		// used by syscall entry function which assumes it's at the end of TLS block, so force it to be .percpu.z_...
-		percpu!(static RSP0: AtomicUsize => "z_RSP0" = AtomicUsize::new(0));
-		
 		// currently in kernel mode so even if we get an interrupt on the new TSS.privilege_stack_table[0] value
 		// the CPU won't pay attention to it
 		let ptr = tss::TSS.get().expect("TSS should be initialised")
 				.set_rsp0(to.kernel_stack.virtual_end().end().align_down());
-		RSP0().store(to.kernel_stack.virtual_end().end().addr, Ordering::Relaxed);
+		percpu_v2!(kernel_stack_top).store(to.kernel_stack.virtual_end().end().addr, Ordering::Relaxed);
 		
 		return inner(from.save_state, to.save_state, preserve, to.ttable.pml4.pml4);
 

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -114,7 +114,7 @@ unsafe impl Hal for Amd64Hal {
 	}
 
 	unsafe fn load_user_tls(ptr: *mut u8) {
-		msr::wrmsr(msr::KERNEL_GS_BASE, ptr.addr() as _);
+		msr::wrmsr(msr::FS_BASE, ptr.addr() as _);
 	}
 
 	unsafe fn construct_tables() -> (Self::KTableTy, Self::TTableTy) {
@@ -309,6 +309,7 @@ pub(super) mod msr {
 	pub const LSTAR: ModelSpecificRegister = ModelSpecificRegister(0xC0000082);
 	pub const CSTAR: ModelSpecificRegister = ModelSpecificRegister(0xC0000083);
 	pub const SFMASK: ModelSpecificRegister = ModelSpecificRegister(0xC0000084);
+	pub const FS_BASE: ModelSpecificRegister = ModelSpecificRegister(0xC0000100);
 	pub const GS_BASE: ModelSpecificRegister = ModelSpecificRegister(0xC0000101);
 	pub const KERNEL_GS_BASE: ModelSpecificRegister = ModelSpecificRegister(0xC0000102);
 

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -131,14 +131,15 @@ unsafe impl Hal for Amd64Hal {
 				.set_rsp0(to.kernel_stack.virtual_end().end().align_down());
 		RSP0().store(to.kernel_stack.virtual_end().end().addr, Ordering::Relaxed);
 		
-		return inner(from.save_state, to.save_state, preserve);
-		
-		#[naked]
-		unsafe extern "C" fn inner(from: &mut Amd64SaveState, to: &Amd64SaveState, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve {
+		return inner(from.save_state, to.save_state, preserve, to.ttable.pml4.pml4);
+
+		#[naked] // todo: convert to normal inline asm
+		unsafe extern "C" fn inner(from: &mut Amd64SaveState, to: &Amd64SaveState, preserve: ContextSwitchPreserve, cr3: Frame) -> ContextSwitchPreserve {
 			// rdi: from
 			// rsi: to
 			// rdx: preserve.0 -> rax
 			// rcx: preserve.1 -> rdx
+			// r8: cr3
 			naked_asm!(
 				// save all registers into `from` Amd64SaveState struct
 				"mov [rdi + {rbx_offset}], rbx",
@@ -151,13 +152,13 @@ unsafe impl Hal for Amd64Hal {
 				"pushf",
 				"pop rbx",
 				"mov [rdi + {rflags_offset}], rbx",
-	
-				//todo: "mov r12, [rsi + {pml4_offset}]",
-				//"mov r13, cr3",
-				//"cmp r12, r13",
-				//"je 2f",
-				//"mov cr3, r12",
-				//"2:",
+
+				// swap page table if needed
+				"mov r13, cr3",
+				"cmp r8, r13",
+				"je 2f",
+				"mov cr3, r8",
+				"2:",
 	
 				// restore all registers from `to` Amd64SaveState struct
 				"mov rbx, [rdi + {rflags_offset}]",
@@ -185,7 +186,6 @@ unsafe impl Hal for Amd64Hal {
 				r14_offset = const offset_of!(Amd64SaveState, r14),
 				r15_offset = const offset_of!(Amd64SaveState, r15),
 				rflags_offset = const offset_of!(Amd64SaveState, rflags),
-				//pml4_offset = const offset_of!(PointerView, ttable.pml4),
 			);
 		}
 	}

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -281,6 +281,10 @@ pub(super) mod msr {
 
 	pub const IA32_APIC_BASE: ModelSpecificRegister = ModelSpecificRegister(0x1B);
 	pub const IA32_TSC_DEADLINE: ModelSpecificRegister = ModelSpecificRegister(0x6e0);
+	pub const STAR: ModelSpecificRegister = ModelSpecificRegister(0xC0000081);
+	pub const LSTAR: ModelSpecificRegister = ModelSpecificRegister(0xC0000082);
+	pub const CSTAR: ModelSpecificRegister = ModelSpecificRegister(0xC0000083);
+	pub const SFMASK: ModelSpecificRegister = ModelSpecificRegister(0xC0000084);
 	pub const GSBase: ModelSpecificRegister = ModelSpecificRegister(0xc0000101);
 
 	// fixme: is this always safe?

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -178,6 +178,11 @@ unsafe impl Hal for Amd64Hal {
 		}
 	}
 
+	fn first_thread_init(tcb: &ThreadControlBlock) {
+		let tss_rsp0 = tcb.kernel_stack.virtual_end().end();
+		tss::TSS.get().expect("no TSS").set_rsp0(tss_rsp0.align_down());
+	}
+
 	const IPI_VECTOR: Vector = Vector(0x30);
 	const SPURIOUS_VECTOR: Vector = Vector(0xFF);
 }

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -209,13 +209,15 @@ unsafe impl Hal for Amd64Hal {
 		tss::TSS.get().expect("no TSS").set_rsp0(tss_rsp0.align_down());
 	}
 
-	#[naked]
-	extern "C" fn switch_to_userspace_at(addr: VirtualAddress) -> ! {
+	extern "C" fn switch_to_userspace_at(addr: VirtualAddress, stack_top: VirtualAddress) -> ! {
 		unsafe {
-			naked_asm!(
-					"mov rcx, rdi", // return address from argument
+			asm!(
+					"mov rsp, {}", // return address from argument
 					"mov r11, 0x202",
-					"sysretq"
+					"sysretq",
+					in(reg) stack_top.addr,
+					in("rcx") addr.addr, // return address from argument
+					options(noreturn)
 			)
 		}
 	}

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -198,10 +198,17 @@ unsafe impl Hal for Amd64Hal {
 
 	fn wait_for_interrupt() {
 		unsafe {
+			let val: u64;
 			asm!(
-				"sti",
+				"pushfq",
+				"pop {}",
+				out(reg) val,
+				options(preserves_flags, pure, nomem)
+			);
+			debug_assert!(val & 0x200 != 0, "should not `wfi` with interrupts disabled");
+			asm!(
 				"hlt",
-				options(nostack, preserves_flags)
+				options(nostack, preserves_flags, nomem)
 			);
 		}
 	}

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -210,8 +210,10 @@ unsafe impl Hal for Amd64Hal {
 	}
 
 	extern "C" fn switch_to_userspace_at(addr: VirtualAddress, stack_top: VirtualAddress) -> ! {
+		crate::hal::get_and_disable_interrupts(); // so we can switch stack without getting interrupted before we get to userspace
 		unsafe {
 			asm!(
+					"swapgs",
 					"mov rsp, {}", // return address from argument
 					"mov r11, 0x202",
 					"sysretq",

--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -4,6 +4,7 @@ use core::fmt::{Debug, Formatter};
 use core::mem::{MaybeUninit, offset_of};
 use core::num::NonZero;
 use kernel_api::memory::mapping::Stack;
+use kernel_api::memory::VirtualAddress;
 use crate::hal::{ContextSwitchPreserve, IpiTarget};
 use crate::hal::{Hal, SaveStateTr, ThreadControlBlock};
 use crate::hal::arch::amd64::interrupts::handler::InterruptStackFrame;
@@ -188,6 +189,17 @@ unsafe impl Hal for Amd64Hal {
 	fn first_thread_init(tcb: &ThreadControlBlock) {
 		let tss_rsp0 = tcb.kernel_stack.virtual_end().end();
 		tss::TSS.get().expect("no TSS").set_rsp0(tss_rsp0.align_down());
+	}
+
+	#[naked]
+	extern "C" fn switch_to_userspace_at(addr: VirtualAddress) -> ! {
+		unsafe {
+			naked_asm!(
+					"mov rcx, rdi", // return address from argument
+					"mov r11, 0x202",
+					"sysretq"
+			)
+		}
 	}
 
 	const IPI_VECTOR: Vector = Vector(0x30);

--- a/kernel/src/hal/arch/amd64/paging.rs
+++ b/kernel/src/hal/arch/amd64/paging.rs
@@ -77,7 +77,7 @@ impl Entry for Amd64Entry {
 
 		let reason = u64::from(reason);
 		let low = (reason & 7) << 9;
-		let high = (reason & 0x7ff8) << (52 - 3);
+		let high = (reason & 0x3ff8) << (52 - 3);
 		let split_reason = low | high;
 		let masked_addr = u64::try_from(frame.start().addr).unwrap() & Self::ADDRESS.0;
 		// FIXME: HACK

--- a/kernel/src/hal/arch/amd64/paging.rs
+++ b/kernel/src/hal/arch/amd64/paging.rs
@@ -46,6 +46,8 @@ bitflags! {
 			const AVL_HIGH = 0x7ff0_0000_0000_0000;
 			const PWT = 1<<3;
 			const PCD = 1<<4;
+			const USER = 1<<2;
+			const NX = 1<<63;
 		}
 	}
 
@@ -89,12 +91,16 @@ impl Entry for Amd64Entry {
 
 impl Debug for Amd64Entry {
 	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-		let mut builder = f.debug_tuple("Amd64Entry");
-		if let Some(f) = self.pointed_frame() {
-			builder.field(&f);
+		write!(f, "Amd64Entry(")?;
+		if let Some(frame) = self.pointed_frame() {
+			Debug::fmt(&frame, &mut *f)?;
 		} else {
-			builder.field(&"<unmapped>");
+			write!(f, "--")?
 		}
-		builder.finish()
+		write!(f, ", ")?;
+		if self.contains(Amd64Entry::USER) { write!(f, "U")?; } else { write!(f, "S")?; }
+		if self.contains(Amd64Entry::WRITABLE) { write!(f, "W")?; } else { write!(f, "R")?; }
+		if self.contains(Amd64Entry::NX) { write!(f, "X")?; } else { write!(f, "E")?; }
+		write!(f, ")")
 	}
 }

--- a/kernel/src/hal/arch/amd64/paging2/mod.rs
+++ b/kernel/src/hal/arch/amd64/paging2/mod.rs
@@ -142,7 +142,7 @@ impl KTable for Amd64TTable {
 
 impl KTable for Amd64KTable {
 	fn translate_page(&self, page: Page) -> Option<Frame> {
-		assert!(page.start().addr < 0xffff_8000_0000_0000, "TTable only handles lower half addresses");
+		assert!(page.start().addr >= 0xffff_8000_0000_0000, "KTable only handles lower half addresses");
 
 		let pdpt = &self.tables.tables()[page.pml4_index() - 256];
 		let pd = pdpt.child_table(page.pdpt_index())?;

--- a/kernel/src/hal/arch/amd64/paging2/mod.rs
+++ b/kernel/src/hal/arch/amd64/paging2/mod.rs
@@ -27,6 +27,7 @@ pub(crate) unsafe fn construct_tables() -> (Amd64KTable, Amd64TTable) {
 
 	let ktable_base = ttable.pml4.pml4().entries[256].pointed_frame()
 			.expect("Invalid TTable");
+	
 	let ktable = Amd64KTable {
 		tables: KTablePtr(ktable_base),
 		allocator: highmem()

--- a/kernel/src/hal/arch/amd64/paging2/mod.rs
+++ b/kernel/src/hal/arch/amd64/paging2/mod.rs
@@ -1,10 +1,12 @@
 #[allow(unused_imports)] use crate::prelude::*;
 use core::arch::asm;
 use core::fmt::{Debug, Formatter};
+use core::ops::DerefMut;
 use kernel_api::bridge::paging::MapPageError;
 use kernel_api::memory::allocator::{PhysicalAllocator};
 use kernel_api::memory::{Frame, Page, PhysicalAddress, AllocError};
 use kernel_api::memory::physical::highmem;
+use kernel_api::sync::{Spinlock, SpinlockGuard};
 use table::{Table, PDPT, PML4, PageIndices};
 use crate::hal::arch::amd64::paging::Amd64Entry;
 use crate::hal::paging2::{KTable, TTable};
@@ -62,19 +64,30 @@ impl Debug for Amd64KTable {
 	}
 }
 
-#[repr(transparent)]
-pub(super) struct TTablePtr(pub(super) Frame); // points to a Table<PML4>
+#[repr(C)]
+pub(super) struct TTablePtr {
+	pub(super) pml4: Frame, // points to a Table<PML4>
+	lock: Spinlock<()>,
+}
 
 impl TTablePtr {
 	fn pml4(&self) -> &Table<PML4> {
 		unsafe {
-			&*self.0.to_page().as_ptr().cast()
+			&*self.pml4.to_page().as_ptr().cast()
 		}
+	}
+
+	fn pml4_lock_mut(&self) -> impl DerefMut<Target = Table<PML4>> + '_ {
+		let guard = self.lock.lock();
+		let table = unsafe {
+			&mut *self.pml4.to_page().as_ptr().cast()
+		};
+		SpinlockGuard::map(guard, move |_| table)
 	}
 
 	fn pml4_mut(&mut self) -> &mut Table<PML4> {
 		unsafe {
-			&mut *self.0.to_page().as_ptr().cast()
+			&mut *self.pml4.to_page().as_ptr().cast()
 		}
 	}
 }
@@ -87,7 +100,10 @@ pub struct Amd64TTable {
 impl Amd64TTable {
 	pub unsafe fn new_unchecked(pml4: Frame) -> Self {
 		Self {
-			pml4: TTablePtr(pml4),
+			pml4: TTablePtr {
+				pml4,
+				lock: Spinlock::new(()),
+			},
 			allocator: highmem()
 		}
 	}
@@ -99,29 +115,20 @@ impl Debug for Amd64TTable {
 	}
 }
 
-impl KTable for Amd64TTable {
-	fn translate_page(&self, page: Page) -> Option<Frame> {
+impl Amd64TTable {
+	fn do_map(pml4: &mut Table<PML4>, page: Page, frame: Frame, reason: u16, allocator: &'static dyn PhysicalAllocator) -> Result<(), MapPageError> {
 		assert!(page.start().addr < 0xffff_8000_0000_0000, "TTable only handles lower half addresses");
 
-		let pdpt = self.pml4.pml4().child_table(page.pml4_index())?;
-		let pd = pdpt.child_table(page.pdpt_index())?;
-		let pt = pd.child_table(page.pd_index())?;
-		pt.entries[page.pt_index()].pointed_frame()
-	}
-
-	fn map_page(&mut self, page: Page, frame: Frame, reason: u16) -> Result<(), MapPageError> {
-		assert!(page.start().addr < 0xffff_8000_0000_0000, "TTable only handles lower half addresses");
-
-		let pdpt = self.pml4.pml4_mut().child_table_or_new(page.pml4_index(), &self.allocator)?;
-		let pd = pdpt.child_table_or_new(page.pdpt_index(), &self.allocator)?;
-		let pt = pd.child_table_or_new(page.pd_index(), &self.allocator)?;
+		let pdpt = pml4.child_table_or_new(page.pml4_index(), &allocator)?;
+		let pd = pdpt.child_table_or_new(page.pdpt_index(), &allocator)?;
+		let pt = pd.child_table_or_new(page.pd_index(), &allocator)?;
 		pt.entries[page.pt_index()].point_to_frame(frame, reason).map_err(|e| MapPageError::AlreadyMapped(e))
 	}
-
-	fn unmap_page(&mut self, page: Page) -> Result<(), ()> {
+	
+	fn do_unmap(pml4: &mut Table<PML4>, page: Page) -> Result<(), ()> {
 		assert!(page.start().addr < 0xffff_8000_0000_0000, "TTable only handles lower half addresses");
 
-		let pdpt = self.pml4.pml4_mut().child_table_mut(page.pml4_index()).ok_or(())?;
+		let pdpt = pml4.child_table_mut(page.pml4_index()).ok_or(())?;
 		let pd = pdpt.child_table_mut(page.pdpt_index()).ok_or(())?;
 		let pt = pd.child_table_mut(page.pd_index()).ok_or(())?;
 		let entry = &mut pt.entries[page.pt_index()];
@@ -137,6 +144,31 @@ impl KTable for Amd64TTable {
 			},
 			(false, _) => Err(())
 		}
+	}
+}
+
+impl KTable for Amd64TTable {
+	fn translate_page(&self, page: Page) -> Option<Frame> {
+		assert!(page.start().addr < 0xffff_8000_0000_0000, "TTable only handles lower half addresses");
+
+		let pdpt = self.pml4.pml4().child_table(page.pml4_index())?;
+		let pd = pdpt.child_table(page.pdpt_index())?;
+		let pt = pd.child_table(page.pd_index())?;
+		pt.entries[page.pt_index()].pointed_frame()
+	}
+
+	fn map_page(&mut self, page: Page, frame: Frame, reason: u16) -> Result<(), MapPageError> {
+		Self::do_map(
+			self.pml4.pml4_mut(),
+			page,
+			frame,
+			reason,
+			self.allocator,
+		)
+	}
+
+	fn unmap_page(&mut self, page: Page) -> Result<(), ()> {
+		Self::do_unmap(self.pml4.pml4_mut(), page)
 	}
 }
 
@@ -183,7 +215,7 @@ impl KTable for Amd64KTable {
 
 impl TTable for Amd64TTable {
 	unsafe fn load(&self) {
-		let addr = self.pml4.0.start().addr;
+		let addr = self.pml4.pml4.start().addr;
 		unsafe { asm!("mov cr3, {}", in(reg) addr); }
 	}
 
@@ -200,8 +232,28 @@ impl TTable for Amd64TTable {
 		}
 
 		Ok(Self {
-			pml4: TTablePtr(pml4_frame),
+			pml4: TTablePtr {
+				pml4: pml4_frame,
+				lock: Spinlock::new(()),
+			},
 			allocator
 		})
+	}
+
+	fn map_page(&self, page: Page, frame: Frame, reason: u16) -> Result<(), MapPageError> {
+		Self::do_map(
+			&mut *self.pml4.pml4_lock_mut(),
+			page,
+			frame,
+			reason,
+			self.allocator
+		)
+	}
+
+	fn unmap_page(&self, page: Page) -> Result<(), ()> {
+		Self::do_unmap(
+			&mut *self.pml4.pml4_lock_mut(),
+			page,
+		)
 	}
 }

--- a/kernel/src/hal/arch/amd64/tss.rs
+++ b/kernel/src/hal/arch/amd64/tss.rs
@@ -1,10 +1,11 @@
 #[allow(unused_imports)] use crate::prelude::*;
 use core::arch::asm;
 use core::cell::SyncUnsafeCell;
-use core::mem;
+use core::ptr::addr_of;
 use kernel_api::memory::VirtualAddress;
 use kernel_api::sync::OnceLock;
 
+// todo: make this thread_local
 pub static TSS: OnceLock<Tss> = OnceLock::new();
 
 struct StaticStack([u8; 3*4096]);
@@ -14,7 +15,8 @@ static DOUBLE_FAULT_STACK: SyncUnsafeCell<StaticStack> = SyncUnsafeCell::new(Sta
 #[repr(C, packed(4))]
 pub struct Tss {
     _res0: u32,
-    privilege_stack_table: [VirtualAddress; 3],
+    // use SyncUnsafeCell so we can modify through a shared reference
+    privilege_stack_table: [SyncUnsafeCell<VirtualAddress>; 3],
     _res1: u64,
     interrupt_stack_table: [VirtualAddress; 7],
     _res2: u64,
@@ -26,7 +28,7 @@ impl Tss {
     pub fn new() -> Tss {
         Tss {
             _res0: 0,
-            privilege_stack_table: [VirtualAddress::new(0); 3],
+            privilege_stack_table: [const { SyncUnsafeCell::new(VirtualAddress::new(0)) }; 3],
             _res1: 0,
             interrupt_stack_table: [
                 VirtualAddress::from(unsafe { DOUBLE_FAULT_STACK.get().add(1) }),
@@ -39,7 +41,13 @@ impl Tss {
             ],
             _res2: 0,
             _res3: 0,
-            io_map_base: mem::size_of::<Tss>() as u16,
+            io_map_base: size_of::<Tss>() as u16,
+        }
+    }
+    
+    pub extern "C" fn set_rsp0(&self, addr: VirtualAddress) {
+        unsafe {
+            asm!("lock xchg qword ptr [{}], {}", in(reg) addr_of!(self.privilege_stack_table[0]), inout(reg) addr.addr => _);
         }
     }
 

--- a/kernel/src/hal/arch/amd64/tss.rs
+++ b/kernel/src/hal/arch/amd64/tss.rs
@@ -45,6 +45,7 @@ impl Tss {
         }
     }
     
+    #[inline]
     pub extern "C" fn set_rsp0(&self, addr: VirtualAddress) {
         unsafe {
             asm!("lock xchg qword ptr [{}], {}", in(reg) addr_of!(self.privilege_stack_table[0]), inout(reg) addr.addr => _);

--- a/kernel/src/hal/exception.rs
+++ b/kernel/src/hal/exception.rs
@@ -4,7 +4,8 @@ use derive_more::Display;
 
 pub struct Exception<'a> {
 	pub ty: Ty,
-	pub registers: &'a mut dyn ExceptionRegisters
+	pub registers: &'a mut dyn ExceptionRegisters,
+	pub user_mode: bool,
 }
 
 pub trait ExceptionRegisters: Debug {

--- a/kernel/src/hal/interrupts_v2/mod.rs
+++ b/kernel/src/hal/interrupts_v2/mod.rs
@@ -14,8 +14,6 @@ pub struct Vector(pub usize);
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Line(pub usize);
 
-percpu!(static LOCAL_INTERRUPT_CONTROLLER: OnceCell<LocalInterruptControllerMeta> = OnceCell::new());
-
 trait LocalInterruptController {
 	
 }

--- a/kernel/src/hal/mod.rs
+++ b/kernel/src/hal/mod.rs
@@ -91,8 +91,8 @@ mod hal_impl {
 	
 	pub fn send_local_eoi(vector: Vector) { <arch::Arch as Hal>::send_local_eoi(vector) }
 	pub fn wait_for_interrupt() { <arch::Arch as Hal>::wait_for_interrupt() }
-	#[inline] pub extern "C" fn switch_to_userspace_at(addr: VirtualAddress) -> ! { <arch::Arch as Hal>::switch_to_userspace_at(addr) }
 	#[inline] pub fn first_thread_init(tcb: &ThreadControlBlock) { <arch::Arch as Hal>::first_thread_init(tcb) }
+	#[inline] pub fn switch_to_userspace_at(addr: VirtualAddress, stack_top: VirtualAddress) -> ! { <arch::Arch as Hal>::switch_to_userspace_at(addr, stack_top) }
 
 	pub const IPI_VECTOR: Vector = <arch::Arch as Hal>::IPI_VECTOR;
 	pub const SPURIOUS_VECTOR: Vector = <arch::Arch as Hal>::SPURIOUS_VECTOR;

--- a/kernel/src/hal/mod.rs
+++ b/kernel/src/hal/mod.rs
@@ -12,6 +12,7 @@ pub(crate) use macros::Hal;
 use paging2::{KTable, TTable};
 use crate::threading::{ThreadControlBlock, ThreadPointer, WakeReason, PointerView};
 use crate::hal::interrupts_v2::Vector;
+use kernel_api::memory::VirtualAddress;
 
 pub enum Result { Success, Failure }
 
@@ -37,12 +38,15 @@ pub unsafe trait Hal {
 	fn get_and_disable_interrupts() -> usize;
 	fn set_interrupts(old_state: usize);
 	unsafe fn load_tls(ptr: *mut u8);
+	unsafe fn load_user_tls(ptr: *mut u8);
 	unsafe fn construct_tables() -> (Self::KTableTy, Self::TTableTy);
-	unsafe extern "C" fn switch_thread(from: &PointerView, to: &PointerView, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve;
+	unsafe extern "C" fn switch_thread(from: &mut PointerView, to: &mut PointerView, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve;
 
 	fn send_ipi(target: IpiTarget) -> ::core::result::Result<(), ()>;
 	fn send_local_eoi(vector: Vector);
 	fn wait_for_interrupt();
+	fn first_thread_init(tcb: &ThreadControlBlock);
+	extern "C" fn switch_to_userspace_at(addr: VirtualAddress, stack_top: VirtualAddress) -> !;
 
 	const IPI_VECTOR: Vector;
 	const SPURIOUS_VECTOR: Vector;
@@ -81,11 +85,14 @@ mod hal_impl {
 	pub unsafe fn load_tls(ptr: *mut u8) { <arch::Arch as Hal>::load_tls(ptr) }
 	pub unsafe fn construct_tables() -> (KTableTy, TTableTy) { <arch::Arch as Hal>::construct_tables() }
 	pub unsafe extern "C" fn switch_thread(from: &PointerView, to: &PointerView, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve { <arch::Arch as Hal>::switch_thread(from, to, preserve) }
+	#[inline] pub unsafe fn load_user_tls(ptr: *mut u8) { <arch::Arch as Hal>::load_user_tls(ptr) }
 
 	pub fn send_ipi(target: IpiTarget) -> ::core::result::Result<(), ()> { <arch::Arch as Hal>::send_ipi(target) }
 	
 	pub fn send_local_eoi(vector: Vector) { <arch::Arch as Hal>::send_local_eoi(vector) }
 	pub fn wait_for_interrupt() { <arch::Arch as Hal>::wait_for_interrupt() }
+	#[inline] pub extern "C" fn switch_to_userspace_at(addr: VirtualAddress) -> ! { <arch::Arch as Hal>::switch_to_userspace_at(addr) }
+	#[inline] pub fn first_thread_init(tcb: &ThreadControlBlock) { <arch::Arch as Hal>::first_thread_init(tcb) }
 
 	pub const IPI_VECTOR: Vector = <arch::Arch as Hal>::IPI_VECTOR;
 	pub const SPURIOUS_VECTOR: Vector = <arch::Arch as Hal>::SPURIOUS_VECTOR;

--- a/kernel/src/hal/mod.rs
+++ b/kernel/src/hal/mod.rs
@@ -84,8 +84,8 @@ mod hal_impl {
 	#[export_name = "__popcorn_set_irq"] pub fn set_interrupts(old_state: usize) { <arch::Arch as Hal>::set_interrupts(old_state) }
 	pub unsafe fn load_tls(ptr: *mut u8) { <arch::Arch as Hal>::load_tls(ptr) }
 	pub unsafe fn construct_tables() -> (KTableTy, TTableTy) { <arch::Arch as Hal>::construct_tables() }
-	pub unsafe extern "C" fn switch_thread(from: &PointerView, to: &PointerView, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve { <arch::Arch as Hal>::switch_thread(from, to, preserve) }
 	#[inline] pub unsafe fn load_user_tls(ptr: *mut u8) { <arch::Arch as Hal>::load_user_tls(ptr) }
+	#[inline] pub unsafe extern "C" fn switch_thread(from: &mut PointerView, to: &mut PointerView, preserve: ContextSwitchPreserve) -> ContextSwitchPreserve { <arch::Arch as Hal>::switch_thread(from, to, preserve) }
 
 	pub fn send_ipi(target: IpiTarget) -> ::core::result::Result<(), ()> { <arch::Arch as Hal>::send_ipi(target) }
 	

--- a/kernel/src/hal/paging2/mod.rs
+++ b/kernel/src/hal/paging2/mod.rs
@@ -31,6 +31,9 @@ pub trait TTable: KTable + Sized {
 	unsafe fn load(&self);
 
 	fn new(ktable: &KTableTy, allocator: &'static dyn PhysicalAllocator) -> Result<Self, AllocError>;
+
+	fn map_page(&self, page: Page, frame: Frame, reason: u16) -> Result<(), MapPageError>;
+	fn unmap_page(&self, page: Page) -> Result<(), ()>;
 }
 
 #[export_name = "__popcorn_paging_ktable_translate_page"]

--- a/kernel/src/hal/timing.rs
+++ b/kernel/src/hal/timing.rs
@@ -3,17 +3,15 @@ use core::cell::OnceCell;
 use kernel_api::time::Instant;
 use crate::hal::interrupts_v2::Vector;
 
-percpu!(static LOCAL_TIMER: OnceCell<TimerMeta> = OnceCell::new());
-
 pub(super) fn init_local_timer(timer: TimerMeta) {
-	match LOCAL_TIMER().try_insert(timer) {
+	match percpu_v2!(local_timer).try_insert(timer) {
 		Ok(_) => {},
 		Err(_) => panic!("`LOCAL_TIMER` already initialised"),
 	}
 }
 
 pub fn local_timer() -> &'static TimerMeta {
-	LOCAL_TIMER().get().expect("`local_timer` not yet initialised")
+	percpu_v2!(local_timer).get().expect("`local_timer` not yet initialised")
 }
 
 pub trait Timer {

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -3,12 +3,9 @@ use core::cell::OnceCell;
 use crate::hal;
 use crate::hal::interrupts_v2::Vector;
 
-percpu!(static DEFER_IRQ: OnceCell<Box<dyn Fn()>> = OnceCell::new());
-
 pub fn global_irq_handler(vector: Vector) {
-	if vector == hal::IPI_VECTOR {
-		// todo: check actual IPI cause instead of blindly assuming self-ipi defer
-		DEFER_IRQ().get().expect("No defer irq handler")();
+	if vector == hal::IPI_VECTOR { 
+		todo!("IPI");
 		hal::get_and_disable_interrupts();
 		hal::send_local_eoi(vector);
 	} else if vector == hal::SPURIOUS_VECTOR {
@@ -21,9 +18,4 @@ pub fn global_irq_handler(vector: Vector) {
 		warn!("Unhandled IRQ: vector {:#x}", vector.0);
 	}
 	// todo: extint
-}
-
-// todo: no
-pub fn set_defer_irq(f: impl Fn() + 'static) {
-	DEFER_IRQ().set(Box::new(f)).unwrap_or_else(|_| panic!());
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -322,7 +322,8 @@ extern "sysv64" fn kstart(handoff_data: &'static utils::handoff::Data) -> ! {
 fn kmain(handoff_data: HandoffWrapper) -> ! {
 	let _ = logging::init();
 
-	let map = unsafe { handoff_data.log.symbol_map.map(|ptr| &*ptr.as_ptr().wrapping_byte_add(0xffff_8000_0000_0000)) };
+	// fixme: lifetime here is wrong and when `handoff_data` gets dropped the symbol map is useless
+	let map = handoff_data.log.symbol_map;
 	*panicking::SYMBOL_MAP.write() = map;
 
 	trace!("Handoff data:\n{handoff_data:x?}");

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -182,9 +182,6 @@ fn syscall_handler() {
 
 #[inline]
 fn exception_handler(exception: &mut hal::exception::Exception) {
-	// todo: update this to signal userspace
-	let is_kernel_mode = true;
-	
 	let backtrace = || {
 		sprintln!("---");
 		sprintln!("{:#x?}", exception.registers);
@@ -198,7 +195,7 @@ fn exception_handler(exception: &mut hal::exception::Exception) {
 	match &exception.ty {
 		// Signalling exceptions
 		ty @ (Ty::FloatingPoint | Ty::IllegalInstruction | Ty::BusFault | Ty::Generic(_)) => {
-			if is_kernel_mode {
+			if !exception.user_mode {
 				error!("Kernel exception occurred at {:#x} - {}:\n{ty}", at, panicking::get_symbol_from_ip(at).name);
 				backtrace();
 				loop {}
@@ -208,7 +205,7 @@ fn exception_handler(exception: &mut hal::exception::Exception) {
 		},
 		ty @ Ty::PageFault(_) => {
 			// todo: check for CoW etc.
-			if is_kernel_mode {
+			if !exception.user_mode {
 				error!("Kernel page fault occurred at {:#x} - {}:\n{ty}", at, panicking::get_symbol_from_ip(at).name);
 				backtrace();
 
@@ -246,16 +243,16 @@ fn exception_handler(exception: &mut hal::exception::Exception) {
 		ty @ (Ty::Nmi | Ty::Panic) => {
 			// todo: BSOD equivalent?
 			error!("Unhandled exception occurred at {:#x} - {}:\n{ty}", at, panicking::get_symbol_from_ip(at).name);
-			if is_kernel_mode { backtrace(); }
+			if !exception.user_mode { backtrace(); }
 			loop {}
 		},
 		ty @ Ty::Debug(DebugTy::Breakpoint) => {
 			warn!("Breakpoint: {:#x} - {}:\n{ty}", at, panicking::get_symbol_from_ip(at).name);
-			if is_kernel_mode { backtrace(); }
+			if !exception.user_mode { backtrace(); }
 		},
 		ty @ Ty::Unknown(_) => {
 			warn!("Ignoring exception at {:#x} - {}:\n{ty}", at, panicking::get_symbol_from_ip(at).name);
-			if is_kernel_mode { backtrace(); }
+			if !exception.user_mode { backtrace(); }
 		},
 	}
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -114,10 +114,8 @@ mod percpu;
 #[cfg(test)]
 pub mod test_harness;
 
-percpu!(static FOO: UnsafeCell<usize> = UnsafeCell::new(6));
-
 fn get_foo() -> usize {
-	unsafe { *FOO().get() }
+	unsafe { *percpu_v2!(foo).get() }
 }
 
 #[macro_export]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -176,7 +176,9 @@ macro_rules! assert_unsafe_precondition {
 }
 
 #[inline]
-fn syscall_handler() {
+extern "C" fn syscall_handler(num_low: u64, num_high: u64, a: u64, b: u64, c: u64, d: u64) -> i64 {
+	debug!("syscall({num_high:#x}{num_low:016x}, {a:#x}, {b:#x}, {c:#x}, {d:#x})");
+	todo!()
 
 }
 

--- a/kernel/src/percpu.rs
+++ b/kernel/src/percpu.rs
@@ -1,4 +1,31 @@
 macro_rules! percpu {
+    ($vis:vis static $ident:ident: $ty:ty => $link:literal = $init:expr $(;)?) => {
+        #[inline(always)]
+        $vis fn $ident() -> &'static $ty {
+            #[repr(transparent)]
+            struct Wrap($ty);
+
+            unsafe impl Sync for Wrap {}
+
+            #[link_section = concat!(".percpu.", $link)]
+            #[used]
+            static PERCPU: Wrap = Wrap($init);
+
+            extern "C" { static __percpu_end: u8; }
+
+            let val: *mut $ty;
+            unsafe {
+                ::core::arch::asm!(
+                    "mov {}, gs:[0]",
+                    out(reg) val,
+                    options(nostack, preserves_flags)
+                );
+            }
+            unsafe {
+                &*val.byte_offset(::core::ptr::addr_of!(PERCPU).byte_offset_from(::core::ptr::addr_of!(__percpu_end)))
+            }
+        }
+    };
     ($vis:vis static $ident:ident: $ty:ty = $init:expr $(;)?) => {
         #[inline(always)]
         $vis fn $ident() -> &'static $ty {
@@ -7,7 +34,7 @@ macro_rules! percpu {
 
             unsafe impl Sync for Wrap {}
 
-            #[link_section = concat!(".percpu.", stringify!($ident))]
+            #[link_section = ".percpu"]
             #[used]
             static PERCPU: Wrap = Wrap($init);
 

--- a/kernel/src/percpu.rs
+++ b/kernel/src/percpu.rs
@@ -1,6 +1,6 @@
-use core::cell::{LazyCell, OnceCell, UnsafeCell};
+use core::cell::{Cell, LazyCell, OnceCell, UnsafeCell};
 use core::sync::atomic::AtomicUsize;
-use kernel_api::sync::IrqCell;
+use kernel_api::sync::{IrqCell, RwSpinlock};
 use crate::threading::{Thread, ThreadId, ThreadPointer};
 use crate::timing::TimerQueue;
 
@@ -55,7 +55,7 @@ percpu_gen! {
         pub scheduler: OnceCell<IrqCell<crate::threading::SchedulerTy>> = OnceCell::new(),
         pub idle_thread: LazyCell<(ThreadId, Thread, UnsafeCell<ThreadPointer>)> = LazyCell::new(crate::threading::create_idle_thread),
         pub local_timer: OnceCell<crate::hal::timing::TimerMeta> = OnceCell::new(),
-        pub current_thread: Option<crate::threading::ThreadPointer> = None,
+        pub current_thread: RwSpinlock<Option<ThreadPointer>> = RwSpinlock::new(None),
     }
 }
 

--- a/kernel/src/percpu.rs
+++ b/kernel/src/percpu.rs
@@ -55,6 +55,7 @@ percpu_gen! {
         pub scheduler: OnceCell<IrqCell<crate::threading::SchedulerTy>> = OnceCell::new(),
         pub idle_thread: LazyCell<(ThreadId, Thread, UnsafeCell<ThreadPointer>)> = LazyCell::new(crate::threading::create_idle_thread),
         pub local_timer: OnceCell<crate::hal::timing::TimerMeta> = OnceCell::new(),
+        pub current_thread: Option<crate::threading::ThreadPointer> = None,
     }
 }
 

--- a/kernel/src/percpu.rs
+++ b/kernel/src/percpu.rs
@@ -1,58 +1,61 @@
-macro_rules! percpu {
-    ($vis:vis static $ident:ident: $ty:ty => $link:literal = $init:expr $(;)?) => {
-        #[inline(always)]
-        $vis fn $ident() -> &'static $ty {
-            #[repr(transparent)]
-            struct Wrap($ty);
+use core::cell::{LazyCell, OnceCell, UnsafeCell};
+use core::sync::atomic::AtomicUsize;
+use kernel_api::sync::IrqCell;
+use crate::threading::{Thread, ThreadId, ThreadPointer};
+use crate::timing::TimerQueue;
 
-            unsafe impl Sync for Wrap {}
+macro_rules! percpu_gen {
+    (pub struct $ident:ident {
+        $(pub $field:ident: $ty:ty = $init:expr),* $(,)?
+    }) => {
+        pub struct $ident {
+            $(pub $field: $ty),* ,
+            pub percpu: *mut $ident,
+        }
 
-            #[link_section = concat!(".percpu.", $link)]
-            #[used]
-            static PERCPU: Wrap = Wrap($init);
-
-            extern "C" { static __percpu_end: u8; }
-
-            let val: *mut $ty;
-            unsafe {
-                ::core::arch::asm!(
-                    "mov {}, gs:[0]",
-                    out(reg) val,
-                    options(nostack, preserves_flags)
+        impl $ident {
+            pub fn init() {
+                let data = ::alloc::boxed::Box::leak(
+                    ::alloc::boxed::Box::new(
+                        $ident {
+                            $($field: $init),* ,
+                            percpu: ::core::ptr::null_mut(),
+                        }
+                    )
                 );
-            }
-            unsafe {
-                &*val.byte_offset(::core::ptr::addr_of!(PERCPU).byte_offset_from(::core::ptr::addr_of!(__percpu_end)))
+                data.percpu = data as *mut _;
+                unsafe { crate::hal::load_tls((data as *mut $ident).cast()); }
             }
         }
-    };
-    ($vis:vis static $ident:ident: $ty:ty = $init:expr $(;)?) => {
-        #[inline(always)]
-        $vis fn $ident() -> &'static $ty {
-            #[repr(transparent)]
-            struct Wrap($ty);
 
-            unsafe impl Sync for Wrap {}
+        macro_rules! percpu_v2 {
+            $(($field) => {{
+                let val: *mut $crate::percpu::Percpu;
 
-            #[link_section = ".percpu"]
-            #[used]
-            static PERCPU: Wrap = Wrap($init);
+                unsafe {
+                    ::core::arch::asm!(
+                        "mov {}, gs:[{}]",
+                        out(reg) val,
+                        const ::core::mem::offset_of!($crate::percpu::Percpu, percpu),
+                        options(nostack, preserves_flags)
+                    );
+                }
 
-            extern "C" { static __percpu_end: u8; }
-
-            let val: *mut $ty;
-            unsafe {
-                ::core::arch::asm!(
-                    "mov {}, gs:[0]",
-                    out(reg) val,
-                    options(nostack, preserves_flags)
-                );
-            }
-            unsafe {
-                &*val.byte_offset(::core::ptr::addr_of!(PERCPU).byte_offset_from(::core::ptr::addr_of!(__percpu_end)))
-            }
+                unsafe { &(*val).$field }
+            }};)*
         }
     };
 }
 
-pub(crate) use percpu;
+percpu_gen! {
+    pub struct Percpu {
+        pub foo: UnsafeCell<usize> = UnsafeCell::new(6),
+        pub local_timer_queue: TimerQueue = TimerQueue::new(),
+        pub kernel_stack_top: AtomicUsize = AtomicUsize::new(0),
+        pub scheduler: OnceCell<IrqCell<crate::threading::SchedulerTy>> = OnceCell::new(),
+        pub idle_thread: LazyCell<(ThreadId, Thread, UnsafeCell<ThreadPointer>)> = LazyCell::new(crate::threading::create_idle_thread),
+        pub local_timer: OnceCell<crate::hal::timing::TimerMeta> = OnceCell::new(),
+    }
+}
+
+pub(crate) use percpu_v2;

--- a/kernel/src/prelude.rs
+++ b/kernel/src/prelude.rs
@@ -9,6 +9,6 @@ pub use alloc::format;
 // Commonly used kernel imports
 pub use log::{error, warn, info, debug, trace};
 pub use crate::{sprint, sprintln, yeet};
-pub(crate) use crate::percpu::percpu;
+pub(crate) use crate::percpu::percpu_v2;
 
 pub use crate::io_ext::IoExt as _;

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -154,6 +154,7 @@ pub fn init(handoff_data: crate::HandoffWrapper) -> (ThreadId, CoreId) {
 		ThreadState::Running,
 		INIT_THREAD_ID,
 	);
+	crate::hal::first_thread_init(&tcb);
 	let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
 
 	assert!(

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -63,9 +63,11 @@ pub use parking::{park, ParkError, WakeReason, WakeTrigger, Waker};
 pub use pointers::{Thread, ThreadPointer};
 pub use sleeping::{sleep, sleep_until};
 pub use thread_control_block::{ThreadState, ThreadControlBlock, PointerView, OwnedView, SharedView};
-pub use yielding::{yield_now, yield_defer};
+pub use yielding::{yield_now, yield_defer, create_idle_thread};
 use crate::hal::paging2::TTable;
 use crate::hal::TTableTy;
+
+pub type SchedulerTy = impl Scheduler;
 
 const INIT_THREAD_NUM: usize = 1;
 const INIT_THREAD_ID: ThreadId = ThreadId { id: non_zero!(INIT_THREAD_NUM) };

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -239,7 +239,7 @@ pub fn spawn_with(f: impl FnOnce() + Send + 'static, name: Cow<'static, str>) ->
 /// 
 /// Returns `None` if the core is idle
 pub fn current_thread() -> Option<ThreadId> {
-	scheduler::local_scheduler().lock().current_thread().map(|t| *t.thread_id)
+	percpu_v2!(current_thread).read().as_ref().map(|t| *t.tcb_ref().thread_id)
 }
 
 fn move_to_global_parking_lot(mut thread: ThreadPointer) {
@@ -293,4 +293,6 @@ pub unsafe extern "C" fn thread_startup() {
 }
 
 #[doc(hidden)]
-pub fn debug() { debug!("{:#?}", scheduler::local_scheduler()); }
+pub fn debug() {
+	debug!("current_thread = {:?}\n{:#?}", *percpu_v2!(current_thread).read(), scheduler::local_scheduler());
+}

--- a/kernel/src/threading/parking.rs
+++ b/kernel/src/threading/parking.rs
@@ -2,6 +2,7 @@ use alloc::sync::{Arc, Weak};
 use core::mem;
 use core::num::NonZeroU16;
 use log::{debug, warn};
+use crate::prelude::percpu_v2;
 use super::{current_thread, scheduler, ThreadId, yield_now, scheduler::Scheduler, ThreadState, PointerState};
 
 /// Park the current thread until it is woken up
@@ -58,8 +59,8 @@ pub fn park(wakers: &[&dyn Waker]) -> Result<WakeReason, ParkError> {
 	let id = current_thread();
 	debug!("Parking thread {:?}", id.unwrap());
 	let weak_ptr = {
-		let mut guard = scheduler::local_scheduler().lock();
-		let thread = guard.current_thread().expect("Cannot park when not running a thread");
+		let mut guard = percpu_v2!(current_thread).write();
+		let thread = guard.as_mut().expect("Cannot park when not running a thread").tcb_mut();
 		let park_state = Arc::new(ParkGaurd { thread_id: *thread.thread_id });
 		let weak_ptr = Arc::downgrade(&park_state);
 		*thread.state = ThreadState::Parked(park_state);

--- a/kernel/src/threading/scheduler.rs
+++ b/kernel/src/threading/scheduler.rs
@@ -41,15 +41,10 @@ pub trait Stealer: Send + Sync {}
 /// A scheduler implementation
 pub trait Scheduler: Debug {
 	/// Creates a new instance of the scheduler
-	fn new(running_thread: ThreadPointer) -> (Self, Box<dyn Injector>, Arc<dyn Stealer>) where Self: Sized;
-
-	/// Returns the [`ThreadId`] for the currently running thread
-	///
-	/// Returns `None` if idle
-	fn current_thread(&mut self) -> Option<PointerView<'_>>;
+	fn new() -> (Self, Box<dyn Injector>, Arc<dyn Stealer>) where Self: Sized;
 
 	/// Prepares to switch threads
-	fn switch_thread_pre(&mut self) -> SchedulerSwitchState<'_>;
+	fn get_next_thread(&mut self) -> Option<ThreadPointer>;
 
 	/// Called after switching threads, including during startup of a new thread
 	///
@@ -68,29 +63,12 @@ pub trait Scheduler: Debug {
 	fn unpark(&mut self, thread_id: ThreadId, reason: WakeReason);
 }
 
-pub enum SchedulerSwitchState<'a> {
-	Switch {
-		/// The previously running thread, which will be passed back to the scheduler in [`Scheduler::switch_thread_post()`]
-		/// after the context switch occurs
-		old_thread: ThreadPointer,
-		/// The new thread to switch to
-		new_thread: PointerView<'a>,
-	},
-	/// No new threads to run, and the current thread has blocked
-	Idle {
-		/// The previously running thread
-		old_thread: ThreadPointer,
-	},
-	/// No new threads to run but the previously running thread is still in a running state
-	NoSwitch,
-	SwitchFromIdle { new_thread: PointerView<'a> },
-}
-
 #[define_opaque(super::SchedulerTy)]
 pub(super) fn create_scheduler_for_current_core(running_thread: ThreadPointer) -> CoreId {
-	let (scheduler, injector, _stealer) = <tickless_round_robin::TicklessRoundRobin as Scheduler>::new(running_thread);
+	let (scheduler, injector, _stealer) = <tickless_round_robin::TicklessRoundRobin as Scheduler>::new();
 	percpu_v2!(scheduler).set(IrqCell::new(scheduler))
 			.expect("Scheduler already initialised");
+	*percpu_v2!(current_thread).write() = Some(running_thread);
 	let mut guard = SCHEDULER_INJECTORS.lock();
 	guard.push(injector);
 	CoreId { id: guard.len() - 1 }

--- a/kernel/src/threading/scheduler.rs
+++ b/kernel/src/threading/scheduler.rs
@@ -28,9 +28,6 @@ use crate::threading::{PointerView, SharedView, ThreadControlBlock, ThreadState}
 #[doc(hidden)]
 mod tickless_round_robin;
 
-/// The [`Scheduler`] for the current core
-percpu!(static SCHEDULER: OnceCell<IrqCell<tickless_round_robin::TicklessRoundRobin>> = OnceCell::new());
-
 /// [`Injector`]s to add new threads to each core
 static SCHEDULER_INJECTORS: Spinlock<Vec<Box<dyn Injector>>> = Spinlock::new(vec![]);
 
@@ -89,10 +86,10 @@ pub enum SchedulerSwitchState<'a> {
 	SwitchFromIdle { new_thread: PointerView<'a> },
 }
 
+#[define_opaque(super::SchedulerTy)]
 pub(super) fn create_scheduler_for_current_core(running_thread: ThreadPointer) -> CoreId {
-	debug_assert!(SCHEDULER().get().is_none(), "Scheduler already initialised");
 	let (scheduler, injector, _stealer) = <tickless_round_robin::TicklessRoundRobin as Scheduler>::new(running_thread);
-	SCHEDULER().set(IrqCell::new(scheduler))
+	percpu_v2!(scheduler).set(IrqCell::new(scheduler))
 			.expect("Scheduler already initialised");
 	let mut guard = SCHEDULER_INJECTORS.lock();
 	guard.push(injector);
@@ -100,7 +97,7 @@ pub(super) fn create_scheduler_for_current_core(running_thread: ThreadPointer) -
 }
 
 pub(super) fn local_scheduler() -> &'static IrqCell<impl Scheduler + Debug> {
-	SCHEDULER().get()
+	percpu_v2!(scheduler).get()
 			.expect("Scheduler not yet initialised")
 }
 

--- a/kernel/src/threading/scheduler/tickless_round_robin/mod.rs
+++ b/kernel/src/threading/scheduler/tickless_round_robin/mod.rs
@@ -2,7 +2,7 @@
 use alloc::collections::VecDeque;
 use alloc::sync::{Arc, Weak};
 use core::fmt::Debug;
-use crate::threading::scheduler::{Scheduler, SchedulerSwitchState};
+use crate::threading::scheduler::Scheduler;
 use crate::threading::{ThreadPointer, WakeReason};
 use event::{Queue, Event};
 use kernel_api::sync::{IrqGuard, Spinlock};
@@ -14,7 +14,6 @@ mod event;
 #[derive(Debug)]
 pub struct TicklessRoundRobin {
 	run_queue: Arc<Spinlock<VecDeque<ThreadPointer>>>,
-	current_thread: Option<ThreadPointer>,
 	event_queue: Queue,
 }
 
@@ -43,10 +42,9 @@ pub struct Stealer {}
 impl super::Stealer for Stealer {}
 
 impl Scheduler for TicklessRoundRobin {
-	fn new(running_thread: ThreadPointer) -> (Self, Box<dyn super::Injector>, Arc<dyn super::Stealer>) where Self: Sized {
+	fn new() -> (Self, Box<dyn super::Injector>, Arc<dyn super::Stealer>) where Self: Sized {
 		let this = Self {
 			run_queue: Arc::new(Spinlock::new(VecDeque::new())),
-			current_thread: Some(running_thread),
 			event_queue: Queue::new(),
 		};
 		let queue = Arc::downgrade(&this.run_queue);
@@ -58,44 +56,8 @@ impl Scheduler for TicklessRoundRobin {
 		)
 	}
 
-	fn current_thread(&mut self) -> Option<PointerView<'_>> {
-		self.current_thread.as_mut()
-		    .map(|t| t.tcb_mut())
-	}
-
-	fn switch_thread_pre(&mut self) -> SchedulerSwitchState<'_> {
-		if let Some(new_thread) = self.run_queue.lock().pop_front() {
-			let old_thread = self.current_thread.replace(new_thread);
-			
-			let new_thread = self.current_thread.as_mut()
-			                     .expect("Just added a new thread")
-			                     .tcb_mut();
-
-			if let Some(old_thread) = old_thread {
-				SchedulerSwitchState::Switch {
-					old_thread,
-					new_thread
-				}
-			} else {
-				SchedulerSwitchState::SwitchFromIdle {
-					new_thread
-				}
-			}
-		} else {
-			#[cfg(feature = "log.scheduler")] debug!("No other tasks");
-			match self.current_thread.as_mut() {
-				Some(current_tcb) => if current_tcb.tcb_mut().state.is_running() || current_tcb.tcb_mut().state.is_ready() {
-					#[cfg(feature = "log.scheduler")] debug!("Can keep running existing thread");
-					SchedulerSwitchState::NoSwitch
-				} else {
-					#[cfg(feature = "log.scheduler")] debug!("Idling");
-					let old_thread = self.current_thread.take()
-					                     .expect("Must be currently running on a thread");
-					SchedulerSwitchState::Idle { old_thread }
-				},
-				None => SchedulerSwitchState::NoSwitch,
-			}
-		}
+	fn get_next_thread(&mut self) -> Option<ThreadPointer> {
+		self.run_queue.lock().pop_front()
 	}
 
 	fn switch_thread_post(&mut self, mut old_thread: ThreadPointer) {
@@ -113,7 +75,8 @@ impl Scheduler for TicklessRoundRobin {
 
 	fn unpark(&mut self, thread_id: ThreadId, reason: WakeReason) {
 		debug!("scheduler local unpark of {thread_id:?} for {reason:?}");
-		let t = self.current_thread.as_mut().expect("`tickless_round_robin` globally parks all threads so unpark a local thread must be the current thread");
+		let mut guard = percpu_v2!(current_thread).write();
+		let t = guard.as_mut().expect("`tickless_round_robin` globally parks all threads so unpark a local thread must be the current thread");
 		assert_eq!(*t.tcb_ref().thread_id, thread_id);
 		debug_assert!(t.tcb_mut().state.is_parked() || t.tcb_mut().state.is_just_unparked());
 		*t.tcb_mut().state = ThreadState::JustUnparked(reason);

--- a/kernel/src/threading/sleeping.rs
+++ b/kernel/src/threading/sleeping.rs
@@ -1,13 +1,13 @@
 use core::time::Duration;
 use kernel_api::time::Instant;
+use crate::prelude::percpu_v2;
 use crate::threading::WakeReason;
-use crate::timing::LOCAL_TIMER_QUEUE;
 
 pub fn sleep(duration: Duration) {
 	sleep_until(Instant::now() + duration);
 }
 
 pub fn sleep_until(wake_time: Instant) {
-	let reason = super::park(&[&LOCAL_TIMER_QUEUE().waker_for(wake_time)]).expect("Failed to park");
+	let reason = super::park(&[&percpu_v2!(local_timer_queue).waker_for(wake_time)]).expect("Failed to park");
 	debug_assert_eq!(reason, WakeReason::Timeout, "`sleep` should only wake due to a timeout");
 }

--- a/kernel/src/threading/yielding.rs
+++ b/kernel/src/threading/yielding.rs
@@ -55,7 +55,7 @@ pub fn yield_defer() {
 /// # Interrupt safety
 /// This function is **not** interrupt safe, and will block any pending interrupts
 pub fn yield_now() -> Option<WakeReason> {
-	fn do_thread_switch(from: ThreadPointer, to_view: PointerView) -> Option<WakeReason> {
+	fn do_thread_switch(from: ThreadPointer, mut to_view: PointerView) -> Option<WakeReason> {
 		// We need to duplicate the `ThreadPointer` so we can pass it to `switch_thread` while it is borrowed
 		// so wrap the first copy in a `ManuallyDrop` to prevent a double free
 		let mut from = ManuallyDrop::new(from);
@@ -65,7 +65,7 @@ pub fn yield_now() -> Option<WakeReason> {
 		// The `PointerView` does not borrow the contents of the `ThreadPointer` - it only requires the
 		// `ThreadPointer` to exist 'somewhere', so holding this borrow while moving the underlying `ThreadPointer`
 		// is safe
-		let from_view = from.tcb_mut();
+		let mut from_view = from.tcb_mut();
 
 		#[cfg(feature = "log.scheduler")] trace!("[a] switch from `{:?}` to `{:?}`", from_view.thread_id, to_view.thread_id);
 
@@ -77,7 +77,7 @@ pub fn yield_now() -> Option<WakeReason> {
 		// From the CPU's perspective during a context switch, `from` is no longer the same `ThreadPointer`
 		// as the stack has been changed. Instead, we replace it with the `ThreadPointer` that `switch_thread`
 		// preserves across the function call
-		let ContextSwitchPreserve(from, reason) = unsafe { hal::switch_thread(&from_view, &to_view, ContextSwitchPreserve(ptr::read(from_ptr), reason)) };
+		let ContextSwitchPreserve(from, reason) = unsafe { hal::switch_thread(&mut from_view, &mut to_view, ContextSwitchPreserve(ptr::read(from_ptr), reason)) };
 
 		post_switch_cleanup(from);
 		

--- a/kernel/src/threading/yielding.rs
+++ b/kernel/src/threading/yielding.rs
@@ -12,30 +12,28 @@ use crate::memory::paging::ktable;
 use crate::threading::scheduler::SchedulerSwitchState;
 use super::{scheduler, WakeReason, ThreadState, scheduler::Scheduler, ThreadPointer, PointerView, Thread, ThreadControlBlock, ThreadId};
 
-percpu! {
-	static IDLE_THREAD: LazyCell<(ThreadId, Thread, UnsafeCell<ThreadPointer>)> = LazyCell::new(|| {
-		extern "C" fn idle_loop(_: usize) -> ! {
-			loop {
-				hal::wait_for_interrupt();
-				yield_now();
-			}
+pub fn create_idle_thread() -> (ThreadId, Thread, UnsafeCell<ThreadPointer>) {
+	extern "C" fn idle_loop(_: usize) -> ! {
+		loop {
+			hal::wait_for_interrupt();
+			yield_now();
 		}
+	}
+
+	let ttable = TTableTy::new(&*ktable(), highmem()).unwrap();
+	let (tcb, id) = ThreadControlBlock::new(
+		"<idle>".into(),
+		ttable,
+		crate::threading::thread_startup,
+		idle_loop,
+		0,
+	);
+
+	let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
 	
-		let ttable = TTableTy::new(&*ktable(), highmem()).unwrap();
-		let (tcb, id) = ThreadControlBlock::new(
-			"<idle>".into(),
-			ttable,
-			crate::threading::thread_startup,
-			idle_loop,
-			0,
-		);
-	
-		let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
-		
-		debug!("Create idle thread with {id:?}");
-	
-		(id, thread, UnsafeCell::new(ptr))
-	});
+	debug!("Create idle thread with {id:?}");
+
+	(id, thread, UnsafeCell::new(ptr))
 }
 
 /// Adds a pending thread switch that will switch threads once all nested interrupts are handled.
@@ -111,7 +109,7 @@ pub fn yield_now() -> Option<WakeReason> {
 				Cannot have more than one `PointerView` alive as it is only materialised here, and immediately dropped
 				Reentrancy cannot occur here as interrupts are disabled due to the scheduler lock
 			 */
-			do_thread_switch(old_thread, unsafe { &mut *IDLE_THREAD().2.get() }.tcb_mut())
+			do_thread_switch(old_thread, unsafe { &mut *percpu_v2!(idle_thread).2.get() }.tcb_mut())
 		},
 		SchedulerSwitchState::SwitchFromIdle { new_thread } => {
 			// Switch from the idle task
@@ -124,7 +122,7 @@ pub fn yield_now() -> Option<WakeReason> {
 				In `post_switch_cleanup()` if the previous thread is the idle thread (as would be the case
 				here), the `ThreadPointer` is dropped and so we are back to only once copy
 			 */
-			do_thread_switch(unsafe { ptr::read(IDLE_THREAD().2.get()) }, new_thread)
+			do_thread_switch(unsafe { ptr::read(percpu_v2!(idle_thread).2.get()) }, new_thread)
 		}
 	}
 }
@@ -133,7 +131,7 @@ pub extern "C" fn post_switch_cleanup(mut previous_thread: ThreadPointer) {
 	let mut guard = unsafe { scheduler::local_scheduler().make_guard_unchecked() };
 	let tcb = previous_thread.tcb_mut();
 	trace!("[b] switch from `{:?}` to current, old blocked in state {:?}", tcb.thread_id, tcb.state);
-	if *tcb.thread_id != IDLE_THREAD().0 {
+	if *tcb.thread_id != percpu_v2!(idle_thread).0 {
 		// Don't enqueue idle thread into a scheduler
 		guard.switch_thread_post(previous_thread);
 	} else {

--- a/kernel/src/threading/yielding.rs
+++ b/kernel/src/threading/yielding.rs
@@ -9,7 +9,6 @@ use kernel_api::sync::{IrqCell, IrqGuard};
 use crate::hal::{ContextSwitchPreserve, self, IpiTarget, TTableTy};
 use crate::hal::paging2::TTable;
 use crate::memory::paging::ktable;
-use crate::threading::scheduler::SchedulerSwitchState;
 use super::{scheduler, WakeReason, ThreadState, scheduler::Scheduler, ThreadPointer, PointerView, Thread, ThreadControlBlock, ThreadId};
 
 pub fn create_idle_thread() -> (ThreadId, Thread, UnsafeCell<ThreadPointer>) {
@@ -30,7 +29,7 @@ pub fn create_idle_thread() -> (ThreadId, Thread, UnsafeCell<ThreadPointer>) {
 	);
 
 	let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
-	
+
 	debug!("Create idle thread with {id:?}");
 
 	(id, thread, UnsafeCell::new(ptr))
@@ -88,47 +87,74 @@ pub fn yield_now() -> Option<WakeReason> {
 	// Wrap it in `ManuallyDrop` since we recreate the guard later, as the thread may have migrated
 	// during the context switch
 	let mut scheduler = ManuallyDrop::new(scheduler::local_scheduler().lock());
+	let mut guard = ManuallyDrop::new(percpu_v2!(current_thread).write());
 	
-	match scheduler.switch_thread_pre() {
-		SchedulerSwitchState::Switch { old_thread, new_thread } => do_thread_switch(old_thread, new_thread),
-		SchedulerSwitchState::NoSwitch => {
-			// No changes occur to scheduler so just return back to thread, but make sure scheduler gets unlocked
-			// as well since that would normally be done by the thread switch
-			let mut scheduler = ManuallyDrop::into_inner(scheduler);
-			match scheduler.current_thread().expect("must be running a thread").state {
-				ThreadState::JustUnparked(reason) => Some(*reason),
-				_ => None,
+	if let Some(new_thread) = scheduler.get_next_thread() {
+		let old_thread = core::mem::replace(&mut **guard, Some(new_thread));
+		let new_thread = guard.as_mut().expect("Just added `new_thread`");
+		
+		match old_thread {
+			Some(old_thread) => do_thread_switch(old_thread, new_thread.tcb_mut()),
+			None => {
+				// no old thread, so switching from the idle thread
+				debug!("stopped idling");
+
+				/*
+					SAFETY:
+					The idle `Thread` object is never dropped, so the `ThreadPointer` is always valid
+					The `ThreadPointer` is duplicated here (which is valid as internally they are raw pointers)
+					and only once instance (passed into `do_thread_switch()`) has mutable references materialised from it.
+					In `post_switch_cleanup()` if the previous thread is the idle thread (as would be the case
+					here), the `ThreadPointer` is dropped and so we are back to only once copy
+				 */
+				do_thread_switch(unsafe { ptr::read(percpu_v2!(idle_thread).2.get()) }, new_thread.tcb_mut())
 			}
-		},
-		SchedulerSwitchState::Idle { old_thread } => {
-			// Switch to the idle task
-			
-			/*
+		}
+	} else {
+		// no new thread, so either keep running old thread, or idle
+		let old_thread = guard.take();
+		
+		match old_thread {
+			Some(mut old_thread) => if old_thread.tcb_mut().state.is_running() || old_thread.tcb_mut().state.is_ready() {
+				debug!("no context switch");
+				
+				// No changes occur to scheduler so just return back to thread, but make sure scheduler gets unlocked
+				// as well since that would normally be done by the thread switch
+				ManuallyDrop::into_inner(scheduler);
+				let mut guard = ManuallyDrop::into_inner(guard);
+				
+				let old_thread = guard.insert(old_thread);
+				
+				match old_thread.tcb_mut().state {
+					ThreadState::JustUnparked(reason) => Some(*reason),
+					_ => None,
+				}
+			} else {
+				// old thread not runnable and no new thread, start idling
+				debug!("start idling");
+
+				/*
 				SAFETY:
 				The idle `Thread` object is never dropped, so the `PointerView` is always valid
 				Cannot have more than one `PointerView` alive as it is only materialised here, and immediately dropped
 				Reentrancy cannot occur here as interrupts are disabled due to the scheduler lock
-			 */
-			do_thread_switch(old_thread, unsafe { &mut *percpu_v2!(idle_thread).2.get() }.tcb_mut())
-		},
-		SchedulerSwitchState::SwitchFromIdle { new_thread } => {
-			// Switch from the idle task
-			
-			/*
-				SAFETY:
-				The idle `Thread` object is never dropped, so the `ThreadPointer` is always valid
-				The `ThreadPointer` is duplicated here (which is valid as internally they are raw pointers)
-				and only once instance (passed into `do_thread_switch()`) has mutable references materialised from it.
-				In `post_switch_cleanup()` if the previous thread is the idle thread (as would be the case
-				here), the `ThreadPointer` is dropped and so we are back to only once copy
-			 */
-			do_thread_switch(unsafe { ptr::read(percpu_v2!(idle_thread).2.get()) }, new_thread)
+			    */
+				do_thread_switch(old_thread, unsafe { &mut *percpu_v2!(idle_thread).2.get() }.tcb_mut())
+			},
+			None => {
+				debug!("continue idle");
+				// just keep running idle thread - see notes on return to old thread
+				ManuallyDrop::into_inner(scheduler);
+				let _ = ManuallyDrop::into_inner(guard);
+				None
+			}
 		}
 	}
 }
 
 pub extern "C" fn post_switch_cleanup(mut previous_thread: ThreadPointer) {
 	let mut guard = unsafe { scheduler::local_scheduler().make_guard_unchecked() };
+	let _ = unsafe { percpu_v2!(current_thread).force_unlock_write() };
 	let tcb = previous_thread.tcb_mut();
 	trace!("[b] switch from `{:?}` to current, old blocked in state {:?}", tcb.thread_id, tcb.state);
 	if *tcb.thread_id != percpu_v2!(idle_thread).0 {

--- a/kernel/src/timing.rs
+++ b/kernel/src/timing.rs
@@ -126,10 +126,8 @@ pub(crate) fn tsc_to_nanos() -> (u128, NonZero<u128>) {
 	})
 }
 
-percpu!(pub static LOCAL_TIMER_QUEUE: TimerQueue = TimerQueue::new());
-
 pub fn local_timer_queue_irq_handler() {
-	LOCAL_TIMER_QUEUE().handle_irq();
+	percpu_v2!(local_timer_queue).handle_irq();
 }
 
 pub struct TimerQueue {
@@ -137,7 +135,7 @@ pub struct TimerQueue {
 }
 
 impl TimerQueue {
-	const fn new() -> Self {
+	pub const fn new() -> Self {
 		Self {
 			heap: IrqCell::new(BinaryHeap::new()),
 		}

--- a/utils/src/handoff.rs
+++ b/utils/src/handoff.rs
@@ -53,7 +53,7 @@ impl ColorMask {
 #[derive(Debug)]
 #[repr(C)]
 pub struct Memory {
-	pub map: Vec<MemoryMapEntry>,
+	pub map: &'static [MemoryMapEntry],
 	pub used: Range<VirtualAddress<4096>>,
 	#[deprecated = "Use HAL methods to construct page tables directly"]
 	pub page_table_root: Frame,
@@ -123,7 +123,7 @@ impl Debug for Modules {
 #[derive(Debug)]
 #[repr(C)]
 pub struct Logging {
-	pub symbol_map: Option<NonNull<[u8]>>
+	pub symbol_map: Option<&'static [u8]>
 }
 
 #[repr(C)]

--- a/utils/src/handoff.rs
+++ b/utils/src/handoff.rs
@@ -13,7 +13,8 @@ pub struct Data {
 	pub log: Logging,
 	pub test: Testing,
 	pub tls: (Range<VirtualAddress>, usize),
-	pub rsdp: PhysicalAddress
+	pub rsdp: PhysicalAddress,
+	pub init_exec: &'static [u8],
 }
 
 #[repr(C)]


### PR DESCRIPTION
- Redo percpu vars again so that calculating offset can be const
- Add userspace switch function
- Add non-exclusive TTable modify methods
- Move current thread into percpu instead of scheduler
- Load `kernel/init.exec` in bootloader and pass to kernel

[amd64]
- Set up syscalls
- Set up swapgs
- Update RSP0 in TSS with thread switches