### PR TITLE
Mixup between `stack.end().end()` and `stack.end().start()` causing stacks to start a page too high

### DIFF
--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -125,8 +125,8 @@ unsafe impl Hal for Amd64Hal {
 		// currently in kernel mode so even if we get an interrupt on the new TSS.privilege_stack_table[0] value
 		// the CPU won't pay attention to it
 		let ptr = tss::TSS.get().expect("TSS should be initialised")
-				.set_rsp0(to.kernel_stack.virtual_end().end().align_down());
-		percpu_v2!(kernel_stack_top).store(to.kernel_stack.virtual_end().end().addr, Ordering::Relaxed);
+				.set_rsp0(to.kernel_stack.virtual_end().start().align_down());
+		percpu_v2!(kernel_stack_top).store(to.kernel_stack.virtual_end().start().addr, Ordering::Relaxed);
 		
 		return inner(from.save_state, to.save_state, preserve);
 
@@ -207,7 +207,7 @@ unsafe impl Hal for Amd64Hal {
 	}
 
 	fn first_thread_init(tcb: &ThreadControlBlock) {
-		let tss_rsp0 = tcb.kernel_stack.virtual_end().end();
+		let tss_rsp0 = tcb.kernel_stack.virtual_end().start();
 		tss::TSS.get().expect("no TSS").set_rsp0(tss_rsp0.align_down());
 	}
 

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -173,7 +173,7 @@ pub fn init(handoff_data: crate::HandoffWrapper) -> (ThreadId, CoreId) {
 		INIT_THREAD_ID,
 		Arc::new(HandleMap::new()),
 	);
-	percpu_v2!(kernel_stack_top).store(tcb.kernel_stack.virtual_end().end().addr, Ordering::Relaxed);
+	percpu_v2!(kernel_stack_top).store(tcb.kernel_stack.virtual_end().start().addr, Ordering::Relaxed);
 	crate::hal::first_thread_init(&tcb);
 	let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
 


### PR DESCRIPTION
Likely the cause of #151 but unconfirmed

Points to a bigger issue with API design