### PR TITLE
Implement multithreading support in `proc` server

### DIFF
--- a/kernel/src/hal/arch/amd64/mod.rs
+++ b/kernel/src/hal/arch/amd64/mod.rs
@@ -293,6 +293,12 @@ impl SaveStateTr for Amd64SaveState {
 			.. Self::default()
 		}
 	}
+
+	unsafe fn set_entry(&mut self, main: extern "C" fn(usize) -> !, args: usize) {
+		let stack_ptr = self.rsp.assume_init_read() as *mut usize;
+		stack_ptr.offset(4).write(main as usize);
+		stack_ptr.offset(3).write(args);
+	}
 }
 
 extern "x86-interrupt" fn breakpoint(frame: InterruptStackFrame) {

--- a/kernel/src/hal/mod.rs
+++ b/kernel/src/hal/mod.rs
@@ -18,6 +18,10 @@ pub enum Result { Success, Failure }
 
 pub trait SaveStateTr: Debug + Default {
 	fn new(tcb: &mut ThreadControlBlock, init: unsafe extern "C" fn(), main: extern "C" fn(usize) -> !, args: usize) -> Self;
+	/// # Safety
+	/// 
+	/// The thread must never have been run
+	unsafe fn set_entry(&mut self, main: extern "C" fn(usize) -> !, args: usize);
 }
 
 #[repr(C)]

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -242,7 +242,8 @@ fn syscall(proto_method: u128, a: usize, b: usize, c: usize, d: usize) -> Result
 		debug!("dispatch to {handle:x?}");
 		
 		let servers = server::servers();
-		let srv = servers.get_server(handle.server_id())?;
+		let srv = servers.get_server(handle.server_id())?.clone();
+		drop(servers);
 		
 		match (meta.a, meta.b, meta.ret) {
 			(ArgTy::Value | ArgTy::None, ArgPairTy::Pair(ArgTy::Value | ArgTy::None, ArgTy::Value | ArgTy::None) | ArgPairTy::None, ArgTy::Value | ArgTy::None) => {

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -118,6 +118,9 @@ pub enum Error {
 	InvalidArg = 5,
 	NameInUse = 6,
 	BadServer = 7,
+	BadHandle = 8,
+	ServerDead = 9,
+	AllocationFailure = 10,
 }
 
 #[repr(transparent)]

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -41,7 +41,7 @@ mod core_protos {
 		pub const PROC_DEALLOC: u128 = 3<<96;
 		pub const THREAD_SET_TCB: u128 = 0<<96;
 		pub const THREAD_EXEC: u128 = 1<<96;
-		pub const THREAD_JOIN: u128 = 2<<96;
+		pub const THREAD_YIELD: u128 = 2<<96;
 	}
 }
 
@@ -113,11 +113,11 @@ static METHODS: LazyLock<HashMap<u128, Method>> = LazyLock::new(|| {
 		}
 	).unwrap();
 	map.try_insert(
-		core_protos::proc::THREAD | core_protos::proc::THREAD_JOIN,
+		core_protos::proc::THREAD | core_protos::proc::THREAD_YIELD,
 		HandledMethod {
 			a: ArgTy::None,
 			b: ArgPairTy::None,
-			ret: ArgTy::Value,
+			ret: ArgTy::None,
 		}
 	).unwrap();
 	map.try_insert(

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -35,11 +35,13 @@ mod core_protos {
 		pub const PROC: u128 = 0x5;
 		pub const THREAD: u128 = 0x6;
 
-		pub const PROC_EXIT: u128 = 0;
+		pub const PROC_EXIT: u128 = 0<<96;
 		pub const PROC_DEBUG: u128 = 1<<96;
 		pub const PROC_ALLOC: u128 = 2<<96;
 		pub const PROC_DEALLOC: u128 = 3<<96;
-		pub const THREAD_SET_TCB: u128 = 0;
+		pub const THREAD_SET_TCB: u128 = 0<<96;
+		pub const THREAD_EXEC: u128 = 1<<96;
+		pub const THREAD_JOIN: u128 = 2<<96;
 	}
 }
 
@@ -99,6 +101,38 @@ static METHODS: LazyLock<HashMap<u128, Method>> = LazyLock::new(|| {
 		HandledMethod {
 			a: ArgTy::Value,
 			b: ArgPairTy::None,
+			ret: ArgTy::Value,
+		}
+	).unwrap();
+	map.try_insert(
+		core_protos::proc::THREAD | core_protos::proc::THREAD_EXEC,
+		HandledMethod {
+			a: ArgTy::Value,
+			b: ArgPairTy::Pair(ArgTy::Value, ArgTy::Value),
+			ret: ArgTy::Value,
+		}
+	).unwrap();
+	map.try_insert(
+		core_protos::proc::THREAD | core_protos::proc::THREAD_JOIN,
+		HandledMethod {
+			a: ArgTy::None,
+			b: ArgPairTy::None,
+			ret: ArgTy::Value,
+		}
+	).unwrap();
+	map.try_insert(
+		core_protos::server::SYNC | core_protos::server::SYNC_GET,
+		HandledMethod {
+			a: ArgTy::None,
+			b: ArgPairTy::OutMemory,
+			ret: ArgTy::Value,
+		}
+	).unwrap();
+	map.try_insert(
+		core_protos::server::SYNC | core_protos::server::SYNC_POST,
+		HandledMethod {
+			a: ArgTy::None,
+			b: ArgPairTy::Memory,
 			ret: ArgTy::Value,
 		}
 	).unwrap();

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -15,7 +15,13 @@ use crate::ipc::protocol::{ArgPairTy, ArgTy, HandledMethod, Method};
 use server::Server as _;
 use crate::memory::r#virtual::AddressSpaceInner;
 
-mod core {
+mod core_protos {
+	pub mod server {
+		pub const SYNC: u128 = 0x7;
+		
+		pub const SYNC_GET: u128 = 0;
+		pub const SYNC_POST: u128 = 1<<96;
+	}
 	pub mod io {
 		pub const WRITE: u128 = 0x2;
 		pub const READ: u128 = 0x3;
@@ -41,7 +47,7 @@ static METHODS: LazyLock<HashMap<u128, Method>> = LazyLock::new(|| {
 	let mut map = HashMap::new();
 
 	map.try_insert(
-		core::io::WRITE | core::io::WRITE_WRITE,
+		core_protos::io::WRITE | core_protos::io::WRITE_WRITE,
 		HandledMethod {
 			a: ArgTy::None,
 			b: ArgPairTy::String, // todo
@@ -49,7 +55,7 @@ static METHODS: LazyLock<HashMap<u128, Method>> = LazyLock::new(|| {
 		}
 	).unwrap();
 	map.try_insert(
-		core::io::READ | core::io::READ_READ,
+		core_protos::io::READ | core_protos::io::READ_READ,
 		HandledMethod {
 			a: ArgTy::None,
 			b: ArgPairTy::OutMemory,
@@ -57,7 +63,7 @@ static METHODS: LazyLock<HashMap<u128, Method>> = LazyLock::new(|| {
 		}
 	).unwrap();
 	map.try_insert(
-		core::proc::PROC | core::proc::PROC_DEBUG,
+		core_protos::proc::PROC | core_protos::proc::PROC_DEBUG,
 		HandledMethod {
 			a: ArgTy::None,
 			b: ArgPairTy::String,
@@ -65,7 +71,7 @@ static METHODS: LazyLock<HashMap<u128, Method>> = LazyLock::new(|| {
 		}
 	).unwrap();
 	map.try_insert(
-		core::proc::PROC | core::proc::PROC_EXIT,
+		core_protos::proc::PROC | core_protos::proc::PROC_EXIT,
 		HandledMethod {
 			a: ArgTy::Value,
 			b: ArgPairTy::None,
@@ -73,7 +79,7 @@ static METHODS: LazyLock<HashMap<u128, Method>> = LazyLock::new(|| {
 		}
 	).unwrap();
 	map.try_insert(
-		core::proc::PROC | core::proc::PROC_ALLOC,
+		core_protos::proc::PROC | core_protos::proc::PROC_ALLOC,
 		HandledMethod {
 			a: ArgTy::Value,
 			b: ArgPairTy::None,
@@ -81,7 +87,7 @@ static METHODS: LazyLock<HashMap<u128, Method>> = LazyLock::new(|| {
 		}
 	).unwrap();
 	map.try_insert(
-		core::proc::PROC | core::proc::PROC_DEALLOC,
+		core_protos::proc::PROC | core_protos::proc::PROC_DEALLOC,
 		HandledMethod {
 			a: ArgTy::Value,
 			b: ArgPairTy::None,
@@ -89,7 +95,7 @@ static METHODS: LazyLock<HashMap<u128, Method>> = LazyLock::new(|| {
 		}
 	).unwrap();
 	map.try_insert(
-		core::proc::THREAD | core::proc::THREAD_SET_TCB,
+		core_protos::proc::THREAD | core_protos::proc::THREAD_SET_TCB,
 		HandledMethod {
 			a: ArgTy::Value,
 			b: ArgPairTy::None,

--- a/kernel/src/ipc/server.rs
+++ b/kernel/src/ipc/server.rs
@@ -54,12 +54,8 @@ impl ServerId {
 
 static SERVERS: LazyLock<RwSpinlock<ServerList>> = LazyLock::new(|| RwSpinlock::new(ServerList::new()));
 
-// fixme: can this be improved?
-static PROC_SERVER_ID: OnceLock<ServerId> = OnceLock::new();
-
 pub fn servers() -> impl Deref<Target = ServerList> { SERVERS.read() }
 pub(super) fn servers_mut() -> impl DerefMut<Target = ServerList> { SERVERS.write() }
-pub fn proc_server() -> ServerId { *PROC_SERVER_ID.get().unwrap() }
 
 #[derive(Debug)]
 pub struct ServerList {
@@ -82,9 +78,8 @@ impl ServerList {
 		list.insert_server(Some(Cow::Borrowed("")), RootServer::new().into())
 				.expect("Not enough servers inserted yet for overflow");
 		
-		let id = list.insert_server(None, ProcServer::new().into())
+		list.insert_server(Some(Cow::Borrowed("proc")), ProcServer::new().into())
 				.expect("Not enough servers inserted yet for overflow");
-		PROC_SERVER_ID.get_or_init(|| id);
 
 		list.insert_server(Some(Cow::Borrowed("console")), ConsoleServer::new().into())
 		    .expect("Not enough servers inserted yet for overflow");

--- a/kernel/src/ipc/server/console.rs
+++ b/kernel/src/ipc/server/console.rs
@@ -5,7 +5,7 @@ use utils::better_cow::Cow;
 use crate::hal::FormatWriter;
 use crate::ipc::{Error, NonNegativeIsize};
 use crate::ipc::server::Server;
-use super::super::core;
+use super::super::core_protos;
 
 /// IO server for the kernel debug console
 /// 
@@ -32,7 +32,7 @@ impl Server for ConsoleServer {
 		if fd != 1 { return Err(Error::Unimplemented); }
 		
 		match proto_method {
-			m if m == const { core::io::WRITE | core::io::WRITE_WRITE } => {
+			m if m == const { core_protos::io::WRITE | core_protos::io::WRITE_WRITE } => {
 				sprint!("{s}");
 				Ok(NonNegativeIsize::new(s.len() as isize).unwrap())
 			}
@@ -44,7 +44,7 @@ impl Server for ConsoleServer {
 		if fd != 1 { return Err(Error::Unimplemented); }
 
 		match proto_method {
-			m if m == const { core::io::READ | core::io::READ_READ } => {
+			m if m == const { core_protos::io::READ | core_protos::io::READ_READ } => {
 				let mut buf = Box::new_uninit_slice(size);
 				for i in 0..size {
 					buf[i].write(crate::hal::SerialOut::read());

--- a/kernel/src/ipc/server/proc.rs
+++ b/kernel/src/ipc/server/proc.rs
@@ -1,4 +1,5 @@
 use ::core::num::NonZero;
+use core::sync::atomic::Ordering;
 use kernel_api::memory::{mapping, VirtualAddress};
 use kernel_api::memory::mapping::{Mapping, new_mapping_in, Protection};
 #[allow(unused_imports)] use crate::prelude::*;
@@ -61,7 +62,7 @@ impl Server for ProcServer {
 					unreachable!()
 				}
 				
-				if !guard.tcb_mut().state.is_uninit() {
+				if !guard.tcb_ref().state.load(Ordering::SeqCst).is_uninit() {
 					debug!("attempt to `exec` an already running thread");
 					return Err(Error::InvalidArg);
 				}

--- a/kernel/src/ipc/server/proc.rs
+++ b/kernel/src/ipc/server/proc.rs
@@ -7,6 +7,8 @@ use crate::ipc::{Error, NonNegativeIsize};
 use crate::ipc::server::Server;
 use crate::memory::r#virtual::AddressSpaceInner;
 use super::super::core_protos;
+use crate::hal::SaveStateTr;
+use crate::threading::ThreadId;
 
 /// Manages thread objects, implementing `core.proc.Proc` and `core.proc.Thread`
 /// 
@@ -38,6 +40,38 @@ impl Server for ProcServer {
 			m if m == const { core_protos::proc::THREAD | core_protos::proc::THREAD_SET_TCB } => {
 				unsupported_other_thread()?;
 				unsafe { crate::hal::load_user_tls(b as _); }
+				return Ok(NonNegativeIsize::new(0).unwrap());
+			}
+			m if m == const { core_protos::proc::THREAD | core_protos::proc::THREAD_EXEC } => {
+				let mut guard = crate::threading::try_get_thread_pointer(ThreadId::new_from(fd.try_into().map_err(|_| Error::InvalidArg)?))
+						.ok_or_else(|| {
+							debug!("could not find ThreadPointer");
+							Error::InvalidArg
+						})?;
+				
+				let userspace_shim = move || {
+					crate::hal::switch_to_userspace_at(VirtualAddress::new(b), VirtualAddress::new(c));
+				};
+				let boxed_userspace = Box::into_raw(Box::new(Box::new(userspace_shim) as Box<dyn FnOnce() + Send + 'static>));
+				extern "C" fn shim(f: usize) -> ! {
+					debug!("started uninit thrad shim");
+					unsafe {
+						Box::from_raw(f as *mut Box<dyn FnOnce() + Send + 'static>)();
+					}
+					unreachable!()
+				}
+				
+				if !guard.tcb_mut().state.is_uninit() {
+					debug!("attempt to `exec` an already running thread");
+					return Err(Error::InvalidArg);
+				}
+				// SAFETY: We just checked the thread is still in an `Uninit` state and therefore has never been run
+				unsafe {
+					guard.tcb_mut().save_state.set_entry(shim, boxed_userspace as usize);
+				}
+				
+				crate::threading::start_uninit_thread(guard);
+
 				return Ok(NonNegativeIsize::new(0).unwrap());
 			}
 			m if m == const { core_protos::proc::PROC | core_protos::proc::PROC_EXIT } => {

--- a/kernel/src/ipc/server/proc.rs
+++ b/kernel/src/ipc/server/proc.rs
@@ -1,5 +1,5 @@
 use ::core::num::NonZero;
-use kernel_api::memory::mapping;
+use kernel_api::memory::{mapping, VirtualAddress};
 use kernel_api::memory::mapping::{Mapping, new_mapping_in, Protection};
 #[allow(unused_imports)] use crate::prelude::*;
 use utils::better_cow::Cow;
@@ -22,22 +22,25 @@ impl Server for ProcServer {
 	}
 
 	fn dispatch_vvv_ve(&self, proto_method: u128, fd: usize, b: usize, c: usize, d: usize) -> Result<NonNegativeIsize, Error> {
-		if fd != percpu_v2!(current_thread).read().as_ref().unwrap().tcb_ref().thread_id.get() { return Err(Error::Unimplemented); }
-		
+		let unsupported_other_thread = || if fd != percpu_v2!(current_thread).read().as_ref().unwrap().tcb_ref().thread_id.get() { Err(Error::Unimplemented) } else { Ok(()) };
+
 		match proto_method {
 			m if m == const { core_protos::proc::THREAD | core_protos::proc::THREAD_SET_TCB } => {
+				unsupported_other_thread()?;
 				unsafe { crate::hal::load_user_tls(b as _); }
 				return Ok(NonNegativeIsize::new(0).unwrap());
 			}
 			m if m == const { core_protos::proc::PROC | core_protos::proc::PROC_EXIT } => {
+				unsupported_other_thread()?;
 				crate::threading::exit(b as i8);
 			}
 			m if m == const { core_protos::proc::PROC | core_protos::proc::PROC_ALLOC } => {
 				let Some(len) = NonZero::new(b) else { return Ok(NonNegativeIsize::new(0).unwrap()); };
 				let len = len.div_ceil(NonZero::new(4096).unwrap());
 
-				let guard = percpu_v2!(current_thread).read();
-				let address_space = guard.as_ref().unwrap().tcb_ref().address_space;
+				let guard = crate::threading::get_thread(ThreadId::new_from(fd.try_into().map_err(|_| Error::InvalidArg)?))
+						.ok_or(Error::InvalidArg)?;
+				let address_space = guard.tcb_ref().address_space;
 
 				let config = mapping::Config::new_in(len.try_into().unwrap(), AddressSpaceInner::to_api(address_space))
 						.protection(Protection::RWXU);
@@ -50,7 +53,9 @@ impl Server for ProcServer {
 
 				Ok(NonNegativeIsize::new(ret).unwrap())
 			}
-			m if m == const { core_protos::proc::PROC | core_protos::proc::PROC_DEALLOC } => { Ok(NonNegativeIsize::new(0).unwrap()) }
+			m if m == const { core_protos::proc::PROC | core_protos::proc::PROC_DEALLOC } => {
+				Ok(NonNegativeIsize::new(0).unwrap())
+			}
 			_ => unimplemented!()
 		}
 	}

--- a/kernel/src/ipc/server/proc.rs
+++ b/kernel/src/ipc/server/proc.rs
@@ -74,6 +74,11 @@ impl Server for ProcServer {
 
 				return Ok(NonNegativeIsize::new(0).unwrap());
 			}
+			m if m == const { core_protos::proc::THREAD | core_protos::proc::THREAD_YIELD } => {
+				unsupported_other_thread()?;
+				let _ = crate::threading::yield_now();
+				Ok(NonNegativeIsize::new(0).unwrap())
+			}
 			m if m == const { core_protos::proc::PROC | core_protos::proc::PROC_EXIT } => {
 				unsupported_other_thread()?;
 				crate::threading::exit(b as i8);

--- a/kernel/src/ipc/server/proc.rs
+++ b/kernel/src/ipc/server/proc.rs
@@ -17,8 +17,18 @@ use super::super::core_protos;
 pub struct ProcServer {}
 
 impl Server for ProcServer {
-	fn open(&self, _endpoint: Cow<'_, Box<str>, str>) -> Result<usize, Error> {
-		unimplemented!()
+	fn open(&self, endpoint: Cow<'_, Box<str>, str>) -> Result<usize, Error> {
+		let endpoint = &*endpoint;
+		if let Some(thread_name) = endpoint.strip_prefix("threads/") {
+			debug!("Create child thread with name `{thread_name}`");
+			let new_tcb = crate::threading::clone_current_uninit(
+				alloc::borrow::Cow::Owned(thread_name.to_owned()),
+			);
+			new_tcb.map(|thread_id| thread_id.get())
+					.map_err(|_| Error::AllocationFailure)
+		} else {
+			Err(Error::Unimplemented)
+		}
 	}
 
 	fn dispatch_vvv_ve(&self, proto_method: u128, fd: usize, b: usize, c: usize, d: usize) -> Result<NonNegativeIsize, Error> {

--- a/kernel/src/ipc/server/proc.rs
+++ b/kernel/src/ipc/server/proc.rs
@@ -6,7 +6,7 @@ use utils::better_cow::Cow;
 use crate::ipc::{Error, NonNegativeIsize};
 use crate::ipc::server::Server;
 use crate::memory::r#virtual::AddressSpaceInner;
-use super::super::core;
+use super::super::core_protos;
 
 /// Manages thread objects, implementing `core.proc.Proc` and `core.proc.Thread`
 /// 
@@ -25,15 +25,14 @@ impl Server for ProcServer {
 		if fd != percpu_v2!(current_thread).read().as_ref().unwrap().tcb_ref().thread_id.get() { return Err(Error::Unimplemented); }
 		
 		match proto_method {
-			m if m == const { core::proc::THREAD | core::proc::THREAD_SET_TCB } => {
+			m if m == const { core_protos::proc::THREAD | core_protos::proc::THREAD_SET_TCB } => {
 				unsafe { crate::hal::load_user_tls(b as _); }
 				return Ok(NonNegativeIsize::new(0).unwrap());
 			}
-			m if m == const { core::proc::PROC | core::proc::PROC_EXIT } => {
-				crate::panicking::stack_trace();
+			m if m == const { core_protos::proc::PROC | core_protos::proc::PROC_EXIT } => {
 				crate::threading::exit(b as i8);
 			}
-			m if m == const { core::proc::PROC | core::proc::PROC_ALLOC } => {
+			m if m == const { core_protos::proc::PROC | core_protos::proc::PROC_ALLOC } => {
 				let Some(len) = NonZero::new(b) else { return Ok(NonNegativeIsize::new(0).unwrap()); };
 				let len = len.div_ceil(NonZero::new(4096).unwrap());
 
@@ -51,14 +50,14 @@ impl Server for ProcServer {
 
 				Ok(NonNegativeIsize::new(ret).unwrap())
 			}
-			m if m == const { core::proc::PROC | core::proc::PROC_DEALLOC } => { Ok(NonNegativeIsize::new(0).unwrap()) }
+			m if m == const { core_protos::proc::PROC | core_protos::proc::PROC_DEALLOC } => { Ok(NonNegativeIsize::new(0).unwrap()) }
 			_ => unimplemented!()
 		}
 	}
 
 	fn dispatch_vs_ve(&self, proto_method: u128, fd: usize, b: usize, s: String) -> Result<NonNegativeIsize, Error> {
 		match proto_method {
-			m if m == const { core::proc::PROC | core::proc::PROC_DEBUG } => {
+			m if m == const { core_protos::proc::PROC | core_protos::proc::PROC_DEBUG } => {
 				info!("log(ThreadId({fd})) - `{s}`");
 				Ok(NonNegativeIsize::new(0).unwrap())
 			}

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -626,7 +626,10 @@ fn kmain(handoff_data: HandoffWrapper) -> ! {
 		let thread = guard.as_ref().unwrap().tcb_ref();
 
 		let stdio_handle = ipc::open("console:/").expect("unable to open console");
-		let thread_handle = Handle::new(ipc::server::proc_server(), thread.thread_id.get());
+		let thread_handle = Handle::new(
+			ipc::server::servers().get_server_at("proc").expect("unable to open `proc`").0,
+			thread.thread_id.get()
+		);
 
 		thread.handles.openat(0, stdio_handle)
 				.expect("unable to open fd 0");

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -86,6 +86,7 @@ use elf::header::program::SegmentType;
 use crate::threading::ThreadControlBlock;
 use handoff_protection::HandoffWrapper;
 use hal::exception::DebugTy;
+use kernel_api::dbg;
 use kernel_api::memory::{Frame};
 use kernel_api::memory::allocator::{Config, SizedBackingAllocator};
 use kernel_api::memory::mapping::{Mapping, self, Location, Stack, Protection, new_mapping_in, new_stack_in};
@@ -185,12 +186,13 @@ macro_rules! assert_unsafe_precondition {
 
 #[inline]
 extern "C" fn syscall_handler(num_low: u64, num_high: u64, a: usize, b: usize, c: usize, d: usize, ip: usize) -> isize {
-	debug!("syscall({num_high:#x}{num_low:016x}, {a:#x}, {b:#x}, {c:#x}, {d:#x}) @ {ip:#x}");
+	debug!("syscall({num_high:#x}{num_low:016x}, {a:#x}, {b:#x}, {c:#x}, {d:#x}) @ {ip:#x} on {:?}", percpu_v2!(current_thread).read().as_ref().unwrap().tcb_ref().thread_id);
 
-	return ipc::syscall_entry(
+	let syscall_result = ipc::syscall_entry(
 		(num_high as u128) << 64 | (num_low as u128),
 		a, b, c, d
 	);
+	dbg!(syscall_result)
 }
 
 #[inline]

--- a/kernel/src/percpu.rs
+++ b/kernel/src/percpu.rs
@@ -1,7 +1,9 @@
-use core::cell::{Cell, LazyCell, OnceCell, UnsafeCell};
+use alloc::sync::Arc;
+use core::cell::{LazyCell, OnceCell, UnsafeCell};
 use core::sync::atomic::AtomicUsize;
+use crossbeam_queue::SegQueue;
 use kernel_api::sync::{IrqCell, RwSpinlock};
-use crate::threading::{Thread, ThreadId, ThreadPointer};
+use crate::threading::{ControlEvent, Thread, ThreadId, ThreadPointer};
 use crate::timing::TimerQueue;
 
 macro_rules! percpu_gen {
@@ -52,7 +54,7 @@ percpu_gen! {
         pub foo: UnsafeCell<usize> = UnsafeCell::new(6),
         pub local_timer_queue: TimerQueue = TimerQueue::new(),
         pub kernel_stack_top: AtomicUsize = AtomicUsize::new(0),
-        pub scheduler: OnceCell<IrqCell<crate::threading::SchedulerTy>> = OnceCell::new(),
+        pub scheduler: OnceCell<(IrqCell<crate::threading::SchedulerTy>, Arc<SegQueue<ControlEvent>>)> = OnceCell::new(),
         pub idle_thread: LazyCell<(ThreadId, Thread, UnsafeCell<ThreadPointer>)> = LazyCell::new(crate::threading::create_idle_thread),
         pub local_timer: OnceCell<crate::hal::timing::TimerMeta> = OnceCell::new(),
         pub current_thread: RwSpinlock<Option<ThreadPointer>> = RwSpinlock::new(None),

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -49,7 +49,7 @@ use kernel_api::memory::{AllocError, Page, VirtualAddress};
 use kernel_api::memory::mapping::{Protection, RawStack, Stack};
 use kernel_api::memory::physical::{highmem, OwnedFrames};
 use kernel_api::memory::r#virtual::{Kernel, OwnedPages};
-use kernel_api::sync::{Spinlock, SpinlockGuard};
+use kernel_api::sync::{LazyLock, OnceLock, Spinlock, SpinlockGuard};
 use crate::{hashmap_new, non_zero};
 use scheduler::Scheduler;
 
@@ -72,6 +72,8 @@ use crate::hal::paging2::TTable;
 use crate::hal::TTableTy;
 use crate::ipc::handle::HandleMap;
 use crate::memory::r#virtual::AddressSpaceInner;
+use crate::threading::parking::ParkGaurd;
+use crate::threading::thread_control_block::AtomicThreadState;
 
 pub type SchedulerTy = impl Scheduler;
 
@@ -80,6 +82,24 @@ const INIT_THREAD_ID: ThreadId = ThreadId { id: non_zero!(INIT_THREAD_NUM) };
 
 /// Global list of all running threads
 static TASK_LIST: Spinlock<HashMap<ThreadId, (Thread, PointerState)>> = Spinlock::new(hashmap_new!());
+
+static THREAD_REAPER: LazyLock<ThreadId> = LazyLock::new(|| spawn_with(||
+	loop {
+		debug!("thread reaper loop running");
+		let mut guard = TASK_LIST.lock();
+		let iter = guard.extract_if(|_, (thread, pointer_state)| {
+			matches!(thread.tcb_ref().state.load(Ordering::SeqCst), ThreadState::Dead)
+			&& matches!(pointer_state, PointerState::GloballyParked(_))
+		});
+		for (_, (thread, pointer)) in iter {
+			debug!("killing {:?}", thread.tcb_ref().thread_id);
+			let PointerState::GloballyParked(pointer) = pointer else { unreachable!("just filtered for globally parked threads") };
+			drop(ThreadControlBlock::from_owned(thread, pointer));
+		}
+		drop(guard);
+		let _ = park(&[]);
+	}, Cow::Borrowed("thread reaper")).expect("could not spawn thread reaper")
+);
 
 #[derive(Debug)]
 enum PointerState {
@@ -176,7 +196,7 @@ pub fn init(handoff_data: crate::HandoffWrapper) -> (ThreadId, CoreId) {
 		Default::default(),
 		Cow::Borrowed("init"),
 		unsafe { Stack::from_contiguous_raw_parts(stack_frames, stack_pages, Protection::RWX, RawStack) }, // FIXME: this should only be RW but that doesn't exist
-		ThreadState::Running,
+		AtomicThreadState::new(ThreadState::Running),
 		INIT_THREAD_ID,
 		Arc::new(HandleMap::new()),
 	);
@@ -288,8 +308,8 @@ pub fn start_uninit_thread(thread_pointer: ThreadPointerGuard<'static>) {
 	
 	match global_thread.1 {
 		PointerState::GloballyParked(ref mut ptr) => {
-			debug!("Enqueue thread {:?} from uninit", ptr.tcb_mut().thread_id);
-			*ptr.tcb_mut().state = ThreadState::Ready;
+			debug!("Enqueue thread {:?} from uninit", ptr.tcb_ref().thread_id);
+			ptr.tcb_ref().state.store(ThreadState::Ready, Ordering::SeqCst);
 			scheduler::enqueue(&mut global_thread.1);
 		},
 		_ => unreachable!("uninit thread cannot be in scheduler"),
@@ -350,8 +370,11 @@ pub fn try_get_thread_pointer(id: ThreadId) -> Option<ThreadPointerGuard<'static
 	ThreadPointerGuard::try_new(guard, id)
 }
 
-fn move_to_global_parking_lot(mut thread: ThreadPointer) {
-	assert!(thread.tcb_mut().state.is_parked(), "Cannot place unparked thread in parking lot");
+fn move_to_global_parking_lot(thread: ThreadPointer) {
+	assert!(
+		matches!(thread.tcb_ref().state.load(Ordering::SeqCst), ThreadState::Parked(_) | ThreadState::Dead),
+		"Cannot place unparked thread in parking lot"
+	);
 
 	debug!("Move {thread:?} to global parking lot");
 
@@ -370,13 +393,40 @@ fn move_to_global_parking_lot(mut thread: ThreadPointer) {
 			);
 		},
 	};
+	
+	if matches!(global_thread.0.tcb_ref().state.load(Ordering::SeqCst), ThreadState::Dead) {
+		drop(guard);
+		parking::do_wake(*THREAD_REAPER, WakeReason::Custom(non_zero!(1)));
+	}
 }
 
 pub fn exit(_exit_code: i8) -> ! {
 	debug!("Exit thread with code {_exit_code}");
-	let _ = park(&[]);
-	// todo: send this to a cleaner thread
+
+	percpu_v2!(current_thread).read().as_ref().expect("cannot exit from idle thread").tcb_ref()
+			.state.store(ThreadState::Dead, Ordering::SeqCst);
+	yield_now();
+	
 	unreachable!("Failed to exit thread");
+}
+
+pub fn kill(thread: ThreadId) {
+	let mut guard = TASK_LIST.lock();
+	let Some(global_thread) = guard.get_mut(&thread) else {
+		warn!("Bad thread id {thread:?}");
+		return;
+	};
+
+	match global_thread.1 {
+		PointerState::InScheduler(core_id) => {
+			scheduler::send_control_event(core_id, ControlEvent::Kill(thread));
+		},
+		PointerState::GloballyParked(ref mut ptr) => {
+			global_thread.0.tcb_ref().state.store(ThreadState::Dead, Ordering::SeqCst);
+			drop(guard);
+			parking::do_wake(*THREAD_REAPER, WakeReason::Custom(non_zero!(1)));
+		},
+	};
 }
 
 #[unsafe(naked)]
@@ -402,5 +452,5 @@ pub unsafe extern "C" fn thread_startup() {
 
 #[doc(hidden)]
 pub fn debug() {
-	debug!("current_thread = {:?}\n{:#?}", *percpu_v2!(current_thread).read(), scheduler::local_scheduler().0);
+	info!("current_thread = {:?}\n{:#?}\n\n{:#?}", *percpu_v2!(current_thread).read(), TASK_LIST, scheduler::local_scheduler().0);
 }

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -46,7 +46,7 @@ use core::ops::{Deref, DerefMut, Range};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use hashbrown::HashMap;
 use kernel_api::memory::{AllocError, Page, VirtualAddress};
-use kernel_api::memory::mapping::{Protection, Stack, RawStack};
+use kernel_api::memory::mapping::{Protection, RawStack, Stack};
 use kernel_api::memory::physical::{highmem, OwnedFrames};
 use kernel_api::memory::r#virtual::{Kernel, OwnedPages};
 use kernel_api::sync::{Spinlock, SpinlockGuard};
@@ -61,13 +61,13 @@ mod sleeping;
 mod thread_control_block;
 mod yielding;
 
-pub use parking::{park, ParkError, WakeReason, WakeTrigger, Waker};
+pub use parking::{park, ParkError, Waker, WakeReason, WakeTrigger};
 pub use pointers::{Thread, ThreadPointer};
 pub use scheduler::ControlEvent;
 use ranged_btree_allocator::RangedBtreeAllocator;
 pub use sleeping::{sleep, sleep_until};
-pub use thread_control_block::{ThreadState, ThreadControlBlock, PointerView, OwnedView, SharedView};
-pub use yielding::{yield_now, yield_defer, create_idle_thread};
+pub use thread_control_block::{OwnedView, PointerView, SharedView, ThreadControlBlock, ThreadState};
+pub use yielding::{create_idle_thread, yield_defer, yield_now};
 use crate::hal::paging2::TTable;
 use crate::hal::TTableTy;
 use crate::ipc::handle::HandleMap;
@@ -83,7 +83,7 @@ static TASK_LIST: Spinlock<HashMap<ThreadId, (Thread, PointerState)>> = Spinlock
 
 #[derive(Debug)]
 enum PointerState {
-	InScheduler,
+	InScheduler(CoreId),
 	GloballyParked(ThreadPointer),
 }
 
@@ -135,7 +135,7 @@ impl ThreadId {
 /// The numerical ID of a CPU core
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct CoreId {
-	id: usize,
+	id: isize,
 }
 
 /// Initializes the scheduler subsystem
@@ -184,14 +184,16 @@ pub fn init(handoff_data: crate::HandoffWrapper) -> (ThreadId, CoreId) {
 	crate::hal::first_thread_init(&tcb);
 	let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
 
+	let core = scheduler::create_scheduler_for_current_core();
+	
 	assert!(
 		TASK_LIST.lock()
-				.try_insert(INIT_THREAD_ID, (thread, PointerState::InScheduler))
+				.try_insert(INIT_THREAD_ID, (thread, PointerState::InScheduler(core)))
 				.is_ok(),
 		"ThreadId(1) should not exist already"
 	);
 	
-	let core = scheduler::create_scheduler_for_current_core(ptr);
+	*percpu_v2!(current_thread).write() = Some(ptr);
 	
 	crate::hal::enable_interrupts();
 
@@ -252,11 +254,11 @@ pub fn spawn_with(f: impl FnOnce() + Send + 'static, name: Cow<'static, str>) ->
 
 	let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
 
-	TASK_LIST.lock()
-	         .try_insert(id, (thread, PointerState::InScheduler))
+	let mut guard = TASK_LIST.lock();
+	let thread = guard.try_insert(id, (thread, PointerState::GloballyParked(ptr)))
 	         .expect("ThreadId reuse");
 
-	scheduler::enqueue(ptr);
+	scheduler::enqueue(&mut thread.1);
 
 	Ok(id)
 }
@@ -285,12 +287,10 @@ pub fn start_uninit_thread(thread_pointer: ThreadPointerGuard<'static>) {
 	let global_thread = guard.get_mut(&tid).expect("we already had a guard to this thread");
 	
 	match global_thread.1 {
-		PointerState::GloballyParked(_) => {
-			let PointerState::GloballyParked(mut ptr) = core::mem::replace(&mut global_thread.1, PointerState::InScheduler) else { unreachable!() };
-
+		PointerState::GloballyParked(ref mut ptr) => {
 			debug!("Enqueue thread {:?} from uninit", ptr.tcb_mut().thread_id);
 			*ptr.tcb_mut().state = ThreadState::Ready;
-			scheduler::enqueue(ptr);
+			scheduler::enqueue(&mut global_thread.1);
 		},
 		_ => unreachable!("uninit thread cannot be in scheduler"),
 	}
@@ -320,7 +320,7 @@ pub struct ThreadPointerGuard<'a> {
 impl<'a> ThreadPointerGuard<'a> {
 	fn try_new(mut guard: SpinlockGuard<'a, HashMap<ThreadId, (Thread, PointerState)>>, id: ThreadId) -> Option<Self> {
 		let val = match &mut guard.get_mut(&id).expect("thread pointer does not exist").1 {
-			PointerState::InScheduler => None,
+			PointerState::InScheduler(_) => None,
 			PointerState::GloballyParked(ptr) => Some(ptr)
 		};
 		Some(ThreadPointerGuard {
@@ -360,7 +360,7 @@ fn move_to_global_parking_lot(mut thread: ThreadPointer) {
 	                         .expect("Cannot park a non-existent thread");
 
 	match global_thread.1 {
-		PointerState::InScheduler => {
+		PointerState::InScheduler(_) => {
 			global_thread.1 = PointerState::GloballyParked(thread);
 		},
 		PointerState::GloballyParked(_) => {
@@ -402,5 +402,5 @@ pub unsafe extern "C" fn thread_startup() {
 
 #[doc(hidden)]
 pub fn debug() {
-	debug!("current_thread = {:?}\n{:#?}", *percpu_v2!(current_thread).read(), scheduler::local_scheduler());
+	debug!("current_thread = {:?}\n{:#?}", *percpu_v2!(current_thread).read(), scheduler::local_scheduler().0);
 }

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -63,6 +63,7 @@ mod yielding;
 
 pub use parking::{park, ParkError, WakeReason, WakeTrigger, Waker};
 pub use pointers::{Thread, ThreadPointer};
+pub use scheduler::ControlEvent;
 use ranged_btree_allocator::RangedBtreeAllocator;
 pub use sleeping::{sleep, sleep_until};
 pub use thread_control_block::{ThreadState, ThreadControlBlock, PointerView, OwnedView, SharedView};

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -60,6 +60,7 @@ mod scheduler;
 mod sleeping;
 mod thread_control_block;
 mod yielding;
+mod subthread_killer;
 
 pub use parking::{park, ParkError, Waker, WakeReason, WakeTrigger};
 pub use pointers::{Thread, ThreadPointer};
@@ -73,6 +74,7 @@ use crate::hal::TTableTy;
 use crate::ipc::handle::HandleMap;
 use crate::memory::r#virtual::AddressSpaceInner;
 use crate::threading::parking::ParkGaurd;
+use crate::threading::subthread_killer::SubthreadKiller;
 use crate::threading::thread_control_block::AtomicThreadState;
 
 pub type SchedulerTy = impl Scheduler;
@@ -90,13 +92,13 @@ static THREAD_REAPER: LazyLock<ThreadId> = LazyLock::new(|| spawn_with(||
 		let iter = guard.extract_if(|_, (thread, pointer_state)| {
 			matches!(thread.tcb_ref().state.load(Ordering::SeqCst), ThreadState::Dead)
 			&& matches!(pointer_state, PointerState::GloballyParked(_))
-		});
+		}).collect::<Vec<_>>();
+		drop(guard);
 		for (_, (thread, pointer)) in iter {
 			debug!("killing {:?}", thread.tcb_ref().thread_id);
 			let PointerState::GloballyParked(pointer) = pointer else { unreachable!("just filtered for globally parked threads") };
 			drop(ThreadControlBlock::from_owned(thread, pointer));
 		}
-		drop(guard);
 		let _ = park(&[]);
 	}, Cow::Borrowed("thread reaper")).expect("could not spawn thread reaper")
 );
@@ -199,6 +201,7 @@ pub fn init(handoff_data: crate::HandoffWrapper) -> (ThreadId, CoreId) {
 		AtomicThreadState::new(ThreadState::Running),
 		INIT_THREAD_ID,
 		Arc::new(HandleMap::new()),
+		SubthreadKiller::new(INIT_THREAD_ID),
 	);
 	percpu_v2!(kernel_stack_top).store(tcb.kernel_stack.virtual_end().start().addr, Ordering::Relaxed);
 	crate::hal::first_thread_init(&tcb);

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -120,6 +120,12 @@ impl ThreadId {
 		}
 	}
 	
+	pub fn new_from(val: NonZero<usize>) -> Self {
+		Self {
+			id: val,
+		}
+	}
+	
 	pub fn get(self) -> usize {
 		self.id.get()
 	}

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -42,14 +42,14 @@ use alloc::sync::Arc;
 use core::arch::{asm, naked_asm};
 use core::fmt::Debug;
 use core::num::NonZero;
-use core::ops::Range;
+use core::ops::{Deref, DerefMut, Range};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use hashbrown::HashMap;
 use kernel_api::memory::{AllocError, Page, VirtualAddress};
 use kernel_api::memory::mapping::{Protection, Stack, RawStack};
 use kernel_api::memory::physical::{highmem, OwnedFrames};
 use kernel_api::memory::r#virtual::{Kernel, OwnedPages};
-use kernel_api::sync::Spinlock;
+use kernel_api::sync::{Spinlock, SpinlockGuard};
 use crate::{hashmap_new, non_zero};
 use scheduler::Scheduler;
 
@@ -259,6 +259,53 @@ pub fn spawn_with(f: impl FnOnce() + Send + 'static, name: Cow<'static, str>) ->
 /// Returns `None` if the core is idle
 pub fn current_thread() -> Option<ThreadId> {
 	percpu_v2!(current_thread).read().as_ref().map(|t| *t.tcb_ref().thread_id)
+}
+
+pub fn get_thread(id: ThreadId) -> Option<impl DerefMut<Target = Thread>> {
+	let guard = TASK_LIST.lock();
+	if guard.get(&id).is_none() { return None; }
+	Some(SpinlockGuard::map(
+		guard,
+		|val| &mut val.get_mut(&id).expect("just checked this exists").0
+	))
+}
+
+pub struct ThreadPointerGuard<'a> {
+	pointer: *mut ThreadPointer,
+	guard: SpinlockGuard<'a, HashMap<ThreadId, (Thread, PointerState)>>,
+}
+
+impl<'a> ThreadPointerGuard<'a> {
+	fn try_new(mut guard: SpinlockGuard<'a, HashMap<ThreadId, (Thread, PointerState)>>, id: ThreadId) -> Option<Self> {
+		let val = match &mut guard.get_mut(&id).expect("thread pointer does not exist").1 {
+			PointerState::InScheduler => None,
+			PointerState::GloballyParked(ptr) => Some(ptr)
+		};
+		Some(ThreadPointerGuard {
+			pointer: val?,
+			guard
+		})
+	}
+}
+
+impl Deref for ThreadPointerGuard<'_> {
+	type Target = ThreadPointer;
+
+	fn deref(&self) -> &Self::Target {
+		unsafe { &*self.pointer }
+	}
+}
+
+impl DerefMut for ThreadPointerGuard<'_> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		unsafe { &mut *self.pointer }
+	}
+}
+
+pub fn try_get_thread_pointer(id: ThreadId) -> Option<ThreadPointerGuard<'static>> {
+	let guard = TASK_LIST.lock();
+	if guard.get(&id).is_none() { return None; }
+	ThreadPointerGuard::try_new(guard, id)
 }
 
 fn move_to_global_parking_lot(mut thread: ThreadPointer) {

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -254,6 +254,41 @@ pub fn spawn_with(f: impl FnOnce() + Send + 'static, name: Cow<'static, str>) ->
 	Ok(id)
 }
 
+pub fn clone_current_uninit(name: Cow<'static, str>) -> Result<ThreadId, AllocError> {
+	let (tcb, id) = ThreadControlBlock::clone_uninit_from(
+		percpu_v2!(current_thread).read().as_ref()
+				.expect("cannot clone non-existent thread")
+				.tcb_ref(),
+		name,
+		thread_startup,
+	);
+
+	let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
+
+	TASK_LIST.lock()
+	         .try_insert(id, (thread, PointerState::GloballyParked(ptr)))
+	         .expect("ThreadId reuse");
+
+	Ok(id)
+}
+
+pub fn start_uninit_thread(thread_pointer: ThreadPointerGuard<'static>) {
+	let tid = *thread_pointer.tcb_ref().thread_id;
+	let ThreadPointerGuard { mut guard, .. } = thread_pointer;
+	let global_thread = guard.get_mut(&tid).expect("we already had a guard to this thread");
+	
+	match global_thread.1 {
+		PointerState::GloballyParked(_) => {
+			let PointerState::GloballyParked(mut ptr) = core::mem::replace(&mut global_thread.1, PointerState::InScheduler) else { unreachable!() };
+
+			debug!("Enqueue thread {:?} from uninit", ptr.tcb_mut().thread_id);
+			*ptr.tcb_mut().state = ThreadState::Ready;
+			scheduler::enqueue(ptr);
+		},
+		_ => unreachable!("uninit thread cannot be in scheduler"),
+	}
+}
+
 /// Gets the [`ThreadId`] for the thread currently running on this core
 /// 
 /// Returns `None` if the core is idle

--- a/kernel/src/threading/mod.rs
+++ b/kernel/src/threading/mod.rs
@@ -52,6 +52,7 @@ use kernel_api::memory::r#virtual::{Kernel, OwnedPages};
 use kernel_api::sync::{LazyLock, OnceLock, Spinlock, SpinlockGuard};
 use crate::{hashmap_new, non_zero};
 use scheduler::Scheduler;
+use crate::hal::SaveStateTr;
 
 mod cleanup;
 mod parking;
@@ -286,22 +287,51 @@ pub fn spawn_with(f: impl FnOnce() + Send + 'static, name: Cow<'static, str>) ->
 	Ok(id)
 }
 
-pub fn clone_current_uninit(name: Cow<'static, str>) -> Result<ThreadId, AllocError> {
+fn clone(name: Cow<'static, str>) -> Result<(ThreadId, ThreadPointerGuard<'static>), AllocError> {
 	let (tcb, id) = ThreadControlBlock::clone_uninit_from(
 		percpu_v2!(current_thread).read().as_ref()
-				.expect("cannot clone non-existent thread")
-				.tcb_ref(),
+		                          .expect("cannot clone non-existent thread")
+		                          .tcb_ref(),
 		name,
 		thread_startup,
 	);
 
 	let (thread, ptr) = ThreadPointer::new(Thread::new(tcb));
 
-	TASK_LIST.lock()
-	         .try_insert(id, (thread, PointerState::GloballyParked(ptr)))
-	         .expect("ThreadId reuse");
+	let mut guard = TASK_LIST.lock();
+	let thread = guard.try_insert(id, (thread, PointerState::GloballyParked(ptr)))
+	            .expect("ThreadId reuse");
+	let ptr = match &mut thread.1 {
+		PointerState::InScheduler(_) => unreachable!(),
+		PointerState::GloballyParked(ptr) => ptr
+	};
+	
+	let guard = ThreadPointerGuard {
+		pointer: ptr,
+		guard
+	};
 
+	Ok((id, guard))
+}
+
+pub fn clone_current(f: impl FnOnce() + Send + 'static, name: Cow<'static, str>) -> Result<ThreadId, AllocError> {
+	extern "C" fn main(ptr: usize) -> ! {
+		let boxed = unsafe { Box::<Box<dyn FnOnce()>>::from_raw(ptr as *mut _) };
+		boxed();
+		exit(0);
+	}
+
+	let boxed = Box::new(f) as Box<dyn FnOnce()>;
+	let boxed = Box::into_raw(Box::new(boxed));
+	
+	let (id, mut thread) = clone(name)?;
+	unsafe { thread.tcb_mut().save_state.set_entry(main, boxed as usize); }
+	start_uninit_thread(thread);
 	Ok(id)
+}
+
+pub fn clone_current_uninit(name: Cow<'static, str>) -> Result<ThreadId, AllocError> {
+	Ok(clone(name)?.0)
 }
 
 pub fn start_uninit_thread(thread_pointer: ThreadPointerGuard<'static>) {

--- a/kernel/src/threading/parking.rs
+++ b/kernel/src/threading/parking.rs
@@ -3,7 +3,7 @@ use core::mem;
 use core::num::NonZeroU16;
 use log::{debug, warn};
 use crate::prelude::percpu_v2;
-use super::{current_thread, scheduler, ThreadId, yield_now, scheduler::Scheduler, ThreadState, PointerState};
+use super::{current_thread, scheduler, ThreadId, yield_now, scheduler::Scheduler, ThreadState, PointerState, ControlEvent};
 
 /// Park the current thread until it is woken up
 ///
@@ -101,27 +101,28 @@ impl WakeTrigger {
 		if let Some(state) = self.park_guard.upgrade() {
 			// FIXME: race condition between upgrading and actually waking which could cause a spurious wakeup
 			let tid = state.thread_id;
-			let mut guard = super::TASK_LIST.lock();
-			let Some(global_thread) = guard.get_mut(&tid) else {
-				warn!("Bad thread id {tid:?}");
-				return;
-			};
-
-			match global_thread.1 {
-				PointerState::InScheduler => {
-					// todo(smp): actually get the right scheduler instead of the current core
-					scheduler::local_scheduler().lock().unpark(tid, reason);
-				},
-				PointerState::GloballyParked(_) => {
-					let PointerState::GloballyParked(mut ptr) = mem::replace(&mut global_thread.1, PointerState::InScheduler) else { unreachable!() };
-					
-					debug!("Enqueue thread {:?} from global parking lot with reason {reason:?}", ptr.tcb_mut().thread_id);
-					*ptr.tcb_mut().state = ThreadState::JustUnparked(reason);
-					scheduler::enqueue(ptr);
-				},
-			};
+			do_wake(tid, reason);
 		}
 	}
+}
+
+pub(super) fn do_wake(thread: ThreadId, reason: WakeReason) {
+	let mut guard = super::TASK_LIST.lock();
+	let Some(global_thread) = guard.get_mut(&thread) else {
+		warn!("Bad thread id {thread:?}");
+		return;
+	};
+
+	match global_thread.1 {
+		PointerState::InScheduler(core_id) => {
+			scheduler::send_control_event(core_id, ControlEvent::Unpark(thread, reason));
+		},
+		PointerState::GloballyParked(ref mut ptr) => {
+			debug!("Enqueue thread {:?} from global parking lot with reason {reason:?}", ptr.tcb_mut().thread_id);
+			*ptr.tcb_mut().state = ThreadState::JustUnparked(reason);
+			scheduler::enqueue(&mut global_thread.1);
+		},
+	};
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/kernel/src/threading/parking.rs
+++ b/kernel/src/threading/parking.rs
@@ -1,7 +1,8 @@
 use alloc::sync::{Arc, Weak};
 use core::mem;
 use core::num::NonZeroU16;
-use log::{debug, warn};
+use core::sync::atomic::Ordering;
+use log::{debug, info, warn};
 use crate::prelude::percpu_v2;
 use super::{current_thread, scheduler, ThreadId, yield_now, scheduler::Scheduler, ThreadState, PointerState, ControlEvent};
 
@@ -63,7 +64,7 @@ pub fn park(wakers: &[&dyn Waker]) -> Result<WakeReason, ParkError> {
 		let thread = guard.as_mut().expect("Cannot park when not running a thread").tcb_mut();
 		let park_state = Arc::new(ParkGaurd { thread_id: *thread.thread_id });
 		let weak_ptr = Arc::downgrade(&park_state);
-		*thread.state = ThreadState::Parked(park_state);
+		thread.state.store(ThreadState::Parked(park_state), Ordering::SeqCst);
 		weak_ptr
 	};
 	// FIXME(preemption): any preemption after this point will cause an early park
@@ -119,7 +120,7 @@ pub(super) fn do_wake(thread: ThreadId, reason: WakeReason) {
 		},
 		PointerState::GloballyParked(ref mut ptr) => {
 			debug!("Enqueue thread {:?} from global parking lot with reason {reason:?}", ptr.tcb_mut().thread_id);
-			*ptr.tcb_mut().state = ThreadState::JustUnparked(reason);
+			ptr.tcb_ref().state.store(ThreadState::JustUnparked(reason), Ordering::SeqCst);
 			scheduler::enqueue(&mut global_thread.1);
 		},
 	};

--- a/kernel/src/threading/pointers.rs
+++ b/kernel/src/threading/pointers.rs
@@ -7,7 +7,7 @@ use super::{PointerView, SharedView, OwnedView, ThreadControlBlock};
 ///
 /// See the [module level documentation](crate::threading#threadcontrolblock-vs-thread-vs-threadpointer-vs-threadid) for more information
 pub struct Thread {
-	ptr: NonNull<ThreadControlBlock>,
+	pub(super) ptr: NonNull<ThreadControlBlock>,
 }
 
 unsafe impl Send for Thread {}
@@ -75,18 +75,20 @@ impl ThreadPointer {
 
 impl Debug for Thread {
 	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-		let thread_id = self.tcb_ref().thread_id;
 		f.debug_struct("Thread")
-		 .field("ThreadId", &thread_id)
+		 .field("id", self.tcb_ref().thread_id)
+		 .field("state", self.tcb_ref().state)
+		 .field("name", self.tcb_ref().name)
 		 .finish_non_exhaustive()
 	}
 }
 
 impl Debug for ThreadPointer {
 	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-		let thread_id = self.tcb_ref().thread_id;
 		f.debug_struct("ThreadPointer")
-		 .field("ThreadId", thread_id)
+		 .field("id", self.tcb_ref().thread_id)
+		 .field("state", self.tcb_ref().state)
+		 .field("name", self.tcb_ref().name)
 		 .finish_non_exhaustive()
 	}
 }

--- a/kernel/src/threading/scheduler.rs
+++ b/kernel/src/threading/scheduler.rs
@@ -13,18 +13,20 @@
 use alloc::sync::Arc;
 use core::cell::OnceCell;
 use core::fmt::Debug;
+use core::mem;
 use core::mem::transmute;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use crate::hal;
 #[cfg(feature = "preemptive")] use core::time::Duration;
+use crossbeam_queue::SegQueue;
 use kernel_api::sync::{IrqCell, IrqGuard, RwSpinlock, Spinlock};
 use kernel_api::time::Instant;
 use crate::hal::paging2::TTable;
 use crate::memory::paging::ktable;
-use crate::{hashmap_new, non_zero, assert_unsafe_precondition};
-use crate::threading::{CoreId, Thread, ThreadId, ThreadPointer, WakeReason};
+use crate::{assert_unsafe_precondition, hashmap_new, non_zero};
+use crate::threading::{CoreId, PointerState, Thread, ThreadId, ThreadPointer, WakeReason};
 use crate::threading::{PointerView, SharedView, ThreadControlBlock, ThreadState};
-use crate::threading::scheduler::control::ControlEvent;
+pub use control::ControlEvent;
 
 #[doc(hidden)]
 mod tickless_round_robin;
@@ -32,6 +34,8 @@ mod control;
 
 /// [`Injector`]s to add new threads to each core
 static SCHEDULER_INJECTORS: RwSpinlock<Vec<Box<dyn Injector>>> = RwSpinlock::new(vec![]);
+
+static SCHEDULER_EVENT_QUEUES: RwSpinlock<Vec<Arc<SegQueue<ControlEvent>>>> = RwSpinlock::new(vec![]);
 
 pub trait Injector: Send + Sync {
 	/// Adds the `thread` to the list of ready-to-run threads in the scheduler
@@ -72,19 +76,22 @@ fn handle_control_event(this: &mut impl Scheduler, event: ControlEvent) {
 }
 
 #[define_opaque(super::SchedulerTy)]
-pub(super) fn create_scheduler_for_current_core(running_thread: ThreadPointer) -> CoreId {
+pub(super) fn create_scheduler_for_current_core() -> CoreId {
 	let (scheduler, injector, _stealer) = <tickless_round_robin::TicklessRoundRobin as Scheduler>::new();
-	percpu_v2!(scheduler).set(IrqCell::new(scheduler))
+	let control_queue = Arc::new(SegQueue::new());
+	percpu_v2!(scheduler).set((IrqCell::new(scheduler), Arc::clone(&control_queue)))
 			.expect("Scheduler already initialised");
-	*percpu_v2!(current_thread).write() = Some(running_thread);
 	let mut guard = SCHEDULER_INJECTORS.write();
 	guard.push(injector);
-	CoreId { id: guard.len() - 1 }
+	let mut guard = SCHEDULER_EVENT_QUEUES.write();
+	guard.push(control_queue);
+	CoreId { id: (guard.len() - 1).try_into().expect("too many cores") }
 }
 
-pub(super) fn local_scheduler() -> &'static IrqCell<impl Scheduler + Debug> {
-	percpu_v2!(scheduler).get()
-			.expect("Scheduler not yet initialised")
+pub(super) fn local_scheduler() -> &'static IrqCell<impl Scheduler> {
+	let (scheduler, _) = percpu_v2!(scheduler).get()
+			.expect("Scheduler not yet initialised");
+	scheduler
 }
 
 /// Enqueues a thread onto a core such that system load stays balanced

--- a/kernel/src/threading/scheduler.rs
+++ b/kernel/src/threading/scheduler.rs
@@ -74,6 +74,7 @@ pub trait Scheduler: Debug {
 	fn enqueue(&mut self, thread: ThreadPointer);
 
 	fn unpark(&mut self, thread_id: ThreadId, reason: WakeReason) -> Result<(), ()>;
+	fn kill(&mut self, thread_id: ThreadId) -> Result<(), ()>;
 }
 
 pub fn handle_control_event(this: &mut (impl Scheduler + ?Sized), event: ControlEvent) {
@@ -85,6 +86,12 @@ pub fn handle_control_event(this: &mut (impl Scheduler + ?Sized), event: Control
 				Err(_) => super::parking::do_wake(thread_id, reason),
 			}
 		},
+		ControlEvent::Kill(thread_id) => {
+			match this.kill(thread_id) {
+				Ok(_) => {},
+				Err(_) => super::do_kill(thread_id),
+			}
+		}
 	}
 }
 

--- a/kernel/src/threading/scheduler.rs
+++ b/kernel/src/threading/scheduler.rs
@@ -50,7 +50,14 @@ pub trait Scheduler: Debug {
 	fn new() -> (Self, Box<dyn Injector>, Arc<dyn Stealer>) where Self: Sized;
 
 	/// Prepares to switch threads
-	fn get_next_thread(&mut self) -> Option<ThreadPointer>;
+	fn get_next_thread_(&mut self) -> Option<ThreadPointer>;
+	
+	fn get_next_thread(&mut self, control_queue: &SegQueue<ControlEvent>) -> Option<ThreadPointer> {
+		while let Some(event) = control_queue.pop() {
+			handle_control_event(self, event);
+		}
+		self.get_next_thread_()
+	}
 
 	/// Called after switching threads, including during startup of a new thread
 	///
@@ -66,13 +73,24 @@ pub trait Scheduler: Debug {
 	/// to reduce locking may be possible
 	fn enqueue(&mut self, thread: ThreadPointer);
 
-	fn unpark(&mut self, thread_id: ThreadId, reason: WakeReason);
+	fn unpark(&mut self, thread_id: ThreadId, reason: WakeReason) -> Result<(), ()>;
 }
 
-fn handle_control_event(this: &mut impl Scheduler, event: ControlEvent) {
+pub fn handle_control_event(this: &mut (impl Scheduler + ?Sized), event: ControlEvent) {
+	debug!("handle scheduler event {event:?}");
 	match event {
-		ControlEvent::Unpark(thread_id, reason) => this.unpark(thread_id, reason),
+		ControlEvent::Unpark(thread_id, reason) => {
+			match this.unpark(thread_id, reason) {
+				Ok(_) => {},
+				Err(_) => super::parking::do_wake(thread_id, reason),
+			}
+		},
 	}
+}
+
+pub fn send_control_event(core: CoreId, event: ControlEvent) {
+	debug!("send control event {event:?} to core {core:?}");
+	SCHEDULER_EVENT_QUEUES.read()[core.id as usize].push(event);
 }
 
 #[define_opaque(super::SchedulerTy)]
@@ -88,17 +106,15 @@ pub(super) fn create_scheduler_for_current_core() -> CoreId {
 	CoreId { id: (guard.len() - 1).try_into().expect("too many cores") }
 }
 
-pub(super) fn local_scheduler() -> &'static IrqCell<impl Scheduler> {
-	let (scheduler, _) = percpu_v2!(scheduler).get()
+pub(super) fn local_scheduler() -> (&'static IrqCell<impl Scheduler>, &'static SegQueue<ControlEvent>) {
+	let (scheduler, queue) = percpu_v2!(scheduler).get()
 			.expect("Scheduler not yet initialised");
-	scheduler
+	(scheduler, queue)
 }
 
 /// Enqueues a thread onto a core such that system load stays balanced
-pub fn enqueue(mut thread: ThreadPointer) {
+pub fn enqueue(thread: &mut PointerState) {
 	static CORE_NUM: AtomicUsize = AtomicUsize::new(0);
-	
-	assert!(thread.tcb_mut().state.is_ready());
 	
 	let injectors = SCHEDULER_INJECTORS.read();
 	assert!(!injectors.is_empty(), "Scheduler not yet initialised");
@@ -106,6 +122,10 @@ pub fn enqueue(mut thread: ThreadPointer) {
 	let injector = &injectors[injector_idx];
 	debug!("Inject into core {injector_idx}");
 
+	let PointerState::GloballyParked(mut ptr) = mem::replace(thread, PointerState::InScheduler(CoreId { id: injector_idx as isize })) else { unreachable!() };
+
+	assert!(ptr.tcb_mut().state.is_ready());
+
 	// fixme: this needs to send an IPI to the corresponding core in case it's idling and needs waking up
-	injector.enqueue(thread);
+	injector.enqueue(ptr);
 }

--- a/kernel/src/threading/scheduler.rs
+++ b/kernel/src/threading/scheduler.rs
@@ -17,7 +17,7 @@ use core::mem::transmute;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use crate::hal;
 #[cfg(feature = "preemptive")] use core::time::Duration;
-use kernel_api::sync::{IrqCell, IrqGuard, Spinlock};
+use kernel_api::sync::{IrqCell, IrqGuard, RwSpinlock, Spinlock};
 use kernel_api::time::Instant;
 use crate::hal::paging2::TTable;
 use crate::memory::paging::ktable;
@@ -29,7 +29,7 @@ use crate::threading::{PointerView, SharedView, ThreadControlBlock, ThreadState}
 mod tickless_round_robin;
 
 /// [`Injector`]s to add new threads to each core
-static SCHEDULER_INJECTORS: Spinlock<Vec<Box<dyn Injector>>> = Spinlock::new(vec![]);
+static SCHEDULER_INJECTORS: RwSpinlock<Vec<Box<dyn Injector>>> = RwSpinlock::new(vec![]);
 
 pub trait Injector: Send + Sync {
 	/// Adds the `thread` to the list of ready-to-run threads in the scheduler
@@ -69,7 +69,7 @@ pub(super) fn create_scheduler_for_current_core(running_thread: ThreadPointer) -
 	percpu_v2!(scheduler).set(IrqCell::new(scheduler))
 			.expect("Scheduler already initialised");
 	*percpu_v2!(current_thread).write() = Some(running_thread);
-	let mut guard = SCHEDULER_INJECTORS.lock();
+	let mut guard = SCHEDULER_INJECTORS.write();
 	guard.push(injector);
 	CoreId { id: guard.len() - 1 }
 }
@@ -85,7 +85,7 @@ pub fn enqueue(mut thread: ThreadPointer) {
 	
 	assert!(thread.tcb_mut().state.is_ready());
 	
-	let injectors = SCHEDULER_INJECTORS.lock();
+	let injectors = SCHEDULER_INJECTORS.read();
 	assert!(!injectors.is_empty(), "Scheduler not yet initialised");
 	let injector_idx = CORE_NUM.fetch_add(1, Ordering::Relaxed) % injectors.len();
 	let injector = &injectors[injector_idx];

--- a/kernel/src/threading/scheduler.rs
+++ b/kernel/src/threading/scheduler.rs
@@ -52,10 +52,7 @@ pub trait Scheduler: Debug {
 	/// Prepares to switch threads
 	fn get_next_thread_(&mut self) -> Option<ThreadPointer>;
 	
-	fn get_next_thread(&mut self, control_queue: &SegQueue<ControlEvent>) -> Option<ThreadPointer> {
-		while let Some(event) = control_queue.pop() {
-			handle_control_event(self, event);
-		}
+	fn get_next_thread(&mut self) -> Option<ThreadPointer> {
 		self.get_next_thread_()
 	}
 
@@ -75,24 +72,6 @@ pub trait Scheduler: Debug {
 
 	fn unpark(&mut self, thread_id: ThreadId, reason: WakeReason) -> Result<(), ()>;
 	fn kill(&mut self, thread_id: ThreadId) -> Result<(), ()>;
-}
-
-pub fn handle_control_event(this: &mut (impl Scheduler + ?Sized), event: ControlEvent) {
-	debug!("handle scheduler event {event:?}");
-	match event {
-		ControlEvent::Unpark(thread_id, reason) => {
-			match this.unpark(thread_id, reason) {
-				Ok(_) => {},
-				Err(_) => super::parking::do_wake(thread_id, reason),
-			}
-		},
-		ControlEvent::Kill(thread_id) => {
-			match this.kill(thread_id) {
-				Ok(_) => {},
-				Err(_) => super::do_kill(thread_id),
-			}
-		}
-	}
 }
 
 pub fn send_control_event(core: CoreId, event: ControlEvent) {
@@ -131,7 +110,7 @@ pub fn enqueue(thread: &mut PointerState) {
 
 	let PointerState::GloballyParked(mut ptr) = mem::replace(thread, PointerState::InScheduler(CoreId { id: injector_idx as isize })) else { unreachable!() };
 
-	assert!(ptr.tcb_mut().state.is_ready());
+	assert!(ptr.tcb_ref().state.load(Ordering::SeqCst).is_ready());
 
 	// fixme: this needs to send an IPI to the corresponding core in case it's idling and needs waking up
 	injector.enqueue(ptr);

--- a/kernel/src/threading/scheduler.rs
+++ b/kernel/src/threading/scheduler.rs
@@ -24,9 +24,11 @@ use crate::memory::paging::ktable;
 use crate::{hashmap_new, non_zero, assert_unsafe_precondition};
 use crate::threading::{CoreId, Thread, ThreadId, ThreadPointer, WakeReason};
 use crate::threading::{PointerView, SharedView, ThreadControlBlock, ThreadState};
+use crate::threading::scheduler::control::ControlEvent;
 
 #[doc(hidden)]
 mod tickless_round_robin;
+mod control;
 
 /// [`Injector`]s to add new threads to each core
 static SCHEDULER_INJECTORS: RwSpinlock<Vec<Box<dyn Injector>>> = RwSpinlock::new(vec![]);
@@ -61,6 +63,12 @@ pub trait Scheduler: Debug {
 	fn enqueue(&mut self, thread: ThreadPointer);
 
 	fn unpark(&mut self, thread_id: ThreadId, reason: WakeReason);
+}
+
+fn handle_control_event(this: &mut impl Scheduler, event: ControlEvent) {
+	match event {
+		ControlEvent::Unpark(thread_id, reason) => this.unpark(thread_id, reason),
+	}
 }
 
 #[define_opaque(super::SchedulerTy)]

--- a/kernel/src/threading/scheduler/control.rs
+++ b/kernel/src/threading/scheduler/control.rs
@@ -3,4 +3,5 @@ use crate::threading::{ThreadId, WakeReason};
 #[derive(Debug)]
 pub enum ControlEvent {
 	Unpark(ThreadId, WakeReason),
+	Kill(ThreadId),
 }

--- a/kernel/src/threading/scheduler/control.rs
+++ b/kernel/src/threading/scheduler/control.rs
@@ -1,0 +1,6 @@
+use crate::threading::{ThreadId, WakeReason};
+
+#[derive(Debug)]
+pub enum ControlEvent {
+	Unpark(ThreadId, WakeReason),
+}

--- a/kernel/src/threading/scheduler/tickless_round_robin/mod.rs
+++ b/kernel/src/threading/scheduler/tickless_round_robin/mod.rs
@@ -65,7 +65,7 @@ impl Scheduler for TicklessRoundRobin {
 		match *old_thread.tcb_mut().state {
 			ThreadState::Parked(_) => threading::move_to_global_parking_lot(old_thread),
 			ThreadState::Ready | ThreadState::JustUnparked(_) => self.enqueue(old_thread),
-			ThreadState::Running => unreachable!(),
+			ThreadState::Running | ThreadState::Uninit => unreachable!(),
 		}
 	}
 

--- a/kernel/src/threading/scheduler/tickless_round_robin/mod.rs
+++ b/kernel/src/threading/scheduler/tickless_round_robin/mod.rs
@@ -2,6 +2,7 @@
 use alloc::collections::VecDeque;
 use alloc::sync::{Arc, Weak};
 use core::fmt::Debug;
+use core::sync::atomic::Ordering;
 use crate::threading::scheduler::Scheduler;
 use crate::threading::{ThreadPointer, WakeReason};
 use event::{Queue, Event};
@@ -60,10 +61,11 @@ impl Scheduler for TicklessRoundRobin {
 		self.run_queue.lock().pop_front()
 	}
 
-	fn switch_thread_post(&mut self, mut old_thread: ThreadPointer) {
-		debug_assert!(!old_thread.tcb_mut().state.is_running());
-		match *old_thread.tcb_mut().state {
-			ThreadState::Parked(_) => threading::move_to_global_parking_lot(old_thread),
+	fn switch_thread_post(&mut self, old_thread: ThreadPointer) {
+		let old_state = old_thread.tcb_ref().state.load(Ordering::SeqCst);
+		debug_assert!(!old_state.is_running());
+		match old_state {
+			ThreadState::Parked(_) | ThreadState::Dead => threading::move_to_global_parking_lot(old_thread),
 			ThreadState::Ready | ThreadState::JustUnparked(_) => self.enqueue(old_thread),
 			ThreadState::Running | ThreadState::Uninit => unreachable!(),
 		}
@@ -77,14 +79,20 @@ impl Scheduler for TicklessRoundRobin {
 		debug!("scheduler local unpark of {thread_id:?} for {reason:?}");
 		let mut guard = percpu_v2!(current_thread).write();
 		let t = guard.as_mut().ok_or(())?;
+		if !matches!(t.tcb_ref().state.load(Ordering::SeqCst), ThreadState::Parked(_) | ThreadState::JustUnparked(_)) { return Ok(()); }
 		if *t.tcb_ref().thread_id == thread_id {
-			debug_assert!(t.tcb_mut().state.is_parked() || t.tcb_mut().state.is_just_unparked());
-			*t.tcb_mut().state = ThreadState::JustUnparked(reason);
+			t.tcb_ref().state.store(ThreadState::JustUnparked(reason), Ordering::SeqCst);
 			Ok(())
 		} else { Err(()) } 
 	}
 
 	fn kill(&mut self, thread_id: ThreadId) -> Result<(), ()> {
-		todo!()
+		let mut guard = self.run_queue.lock();
+		let idx = guard.iter().position(|thread| *thread.tcb_ref().thread_id == thread_id)
+				.ok_or(())?;
+		let mut thread = guard.remove(idx).expect("just found this from iterator position");
+		thread.tcb_mut().state.store(ThreadState::Dead, Ordering::SeqCst);
+		threading::move_to_global_parking_lot(thread);
+		Ok(())
 	}
 }

--- a/kernel/src/threading/scheduler/tickless_round_robin/mod.rs
+++ b/kernel/src/threading/scheduler/tickless_round_robin/mod.rs
@@ -56,7 +56,7 @@ impl Scheduler for TicklessRoundRobin {
 		)
 	}
 
-	fn get_next_thread(&mut self) -> Option<ThreadPointer> {
+	fn get_next_thread_(&mut self) -> Option<ThreadPointer> {
 		self.run_queue.lock().pop_front()
 	}
 
@@ -73,12 +73,14 @@ impl Scheduler for TicklessRoundRobin {
 		self.run_queue.lock().push_back(thread);
 	}
 
-	fn unpark(&mut self, thread_id: ThreadId, reason: WakeReason) {
+	fn unpark(&mut self, thread_id: ThreadId, reason: WakeReason) -> Result<(), ()> {
 		debug!("scheduler local unpark of {thread_id:?} for {reason:?}");
 		let mut guard = percpu_v2!(current_thread).write();
-		let t = guard.as_mut().expect("`tickless_round_robin` globally parks all threads so unpark a local thread must be the current thread");
-		assert_eq!(*t.tcb_ref().thread_id, thread_id);
-		debug_assert!(t.tcb_mut().state.is_parked() || t.tcb_mut().state.is_just_unparked());
-		*t.tcb_mut().state = ThreadState::JustUnparked(reason);
+		let t = guard.as_mut().ok_or(())?;
+		if *t.tcb_ref().thread_id == thread_id {
+			debug_assert!(t.tcb_mut().state.is_parked() || t.tcb_mut().state.is_just_unparked());
+			*t.tcb_mut().state = ThreadState::JustUnparked(reason);
+			Ok(())
+		} else { Err(()) } 
 	}
 }

--- a/kernel/src/threading/scheduler/tickless_round_robin/mod.rs
+++ b/kernel/src/threading/scheduler/tickless_round_robin/mod.rs
@@ -83,4 +83,8 @@ impl Scheduler for TicklessRoundRobin {
 			Ok(())
 		} else { Err(()) } 
 	}
+
+	fn kill(&mut self, thread_id: ThreadId) -> Result<(), ()> {
+		todo!()
+	}
 }

--- a/kernel/src/threading/subthread_killer.rs
+++ b/kernel/src/threading/subthread_killer.rs
@@ -1,0 +1,58 @@
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, Ordering};
+use log::error;
+use kernel_api::sync::Spinlock;
+use crate::threading::ThreadId;
+
+#[derive(Debug, Clone)]
+pub struct SubthreadKiller {
+	inner: Arc<SubthreadKillerInner>
+}
+
+#[derive(Debug)]
+struct SubthreadKillerInner {
+	dead: AtomicBool,
+	list: Spinlock<Vec<ThreadId>>,
+}
+
+impl SubthreadKiller {
+	pub fn new(thread_id: ThreadId) -> Self {
+		Self {
+			inner: Arc::new(SubthreadKillerInner {
+				dead: AtomicBool::new(false),
+				list: Spinlock::new(vec![thread_id]),
+			})
+		}
+	}
+	
+	pub fn add_thread(&self, thread_id: ThreadId) {
+		self.inner.list.lock().push(thread_id);
+	}
+}
+
+impl SubthreadKillerInner {
+	fn kill(&self) {
+		if self.dead.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_ok() {
+			for thread in &*self.list.lock() {
+				super::kill(*thread);
+			}
+		}
+	}
+}
+
+impl Drop for SubthreadKiller {
+	fn drop(&mut self) {
+		self.inner.kill();
+	}
+}
+
+impl Drop for SubthreadKillerInner {
+	fn drop(&mut self) {
+		if !self.dead.load(Ordering::SeqCst) {
+			error!("subthread killer dropped without killing");
+			self.kill();
+		}
+	}
+}

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -2,12 +2,15 @@
 use alloc::borrow::Cow;
 use alloc::sync::Arc;
 use core::cell::UnsafeCell;
-use core::num::NonZeroUsize;
+use core::fmt::{Debug, Formatter};
+use core::num::{NonZero, NonZeroUsize};
+use core::ptr;
+use core::sync::atomic::{AtomicU128, Ordering};
 use kernel_api::memory::mapping;
 use kernel_api::memory::mapping::{new_stack, Stack};
 use kernel_api::memory::r#virtual::Kernel;
 use crate::hal::{self, SaveState, TTableTy};
-use super::{parking::ParkGaurd, ThreadId, WakeReason};
+use super::{parking::ParkGaurd, Thread, ThreadId, ThreadPointer, WakeReason};
 use crate::hal::SaveStateTr;
 use crate::ipc::handle::HandleMap;
 use crate::memory::r#virtual::AddressSpaceInner;
@@ -118,7 +121,7 @@ tcb_views! {
 		/// The stack that kernel code runs on inside the thread
 		kernel_stack: Stack<'static, Kernel>,
 		/// The current running state of the thread
-		#mut(Pointer) state: ThreadState,
+		state: AtomicThreadState,
 		/// The numerical ID of the thread
 		thread_id: ThreadId,
 		//// The currently open handles
@@ -171,7 +174,7 @@ impl ThreadControlBlock {
 			Default::default(),
 			name,
 			new_stack,
-			ThreadState::Ready,
+			AtomicThreadState::new(ThreadState::Ready),
 			id,
 			Arc::new(HandleMap::new()),
 		);
@@ -196,7 +199,7 @@ impl ThreadControlBlock {
 			Default::default(),
 			name,
 			new_stack,
-			ThreadState::Uninit,
+			AtomicThreadState::new(ThreadState::Uninit),
 			id,
 			Arc::clone(from.handles),
 		);
@@ -204,12 +207,81 @@ impl ThreadControlBlock {
 
 		(new_thread, id)
 	}
+	
+	pub fn from_owned(thread: Thread, _pointer: ThreadPointer) -> Self {
+		unsafe { *Box::from_raw(thread.ptr.as_ptr()) }
+	}
 }
 
 impl Drop for ThreadControlBlock {
 	fn drop(&mut self) {
 		debug!("dropped TCB for thread {:?}", self.thread_id);
-		assert!(!self.state.get_mut().is_running(), "Cannot drop currently running thread as this would remove the current stack");
+		assert!(!self.state.load(Ordering::SeqCst).is_running(), "Cannot drop currently running thread as this would remove the current stack");
+	}
+}
+
+pub struct AtomicThreadState(AtomicU128);
+
+impl AtomicThreadState {
+	fn to_raw(state: ThreadState) -> u128 {
+		let (high, low): (usize, usize) = match state {
+			ThreadState::Ready => (0, 0),
+			ThreadState::Running => (1, 0),
+			ThreadState::Parked(park) => (2, Arc::into_raw(park).expose_provenance()),
+			ThreadState::JustUnparked(WakeReason::Timeout) => (3, 0),
+			ThreadState::JustUnparked(WakeReason::Custom(val)) => (3, val.get() as usize),
+			ThreadState::Uninit => (4, 0),
+			ThreadState::Dead => (5, 0),
+		};
+
+		(high as u128) << 64 | (low as u128)
+	}
+
+	fn from_raw(val: u128) -> ThreadState {
+		let (high, low) = ((val >> 64) as usize, val as usize);
+
+		match high {
+			0 => ThreadState::Ready,
+			1 => ThreadState::Running,
+			2 => {
+				let arc = unsafe { Arc::from_raw(ptr::with_exposed_provenance(low)) };
+				// since we store an arc ourselves
+				unsafe { Arc::increment_strong_count(Arc::as_ptr(&arc)) };
+				ThreadState::Parked(arc)
+			},
+			3 => ThreadState::JustUnparked(match NonZero::new(low as u16) {
+				None => WakeReason::Timeout,
+				Some(val) => WakeReason::Custom(val),
+			}),
+			4 => ThreadState::Uninit,
+			5 => ThreadState::Dead,
+			_ => unreachable!()
+		}
+	}
+
+	pub fn new(state: ThreadState) -> Self {
+		AtomicThreadState(AtomicU128::new(Self::to_raw(state)))
+	}
+
+	pub fn store(&self, state: ThreadState, ordering: Ordering) {
+		self.0.store(Self::to_raw(state), ordering);
+	}
+
+	pub fn load(&self, ordering: Ordering) -> ThreadState {
+		let val = self.0.load(ordering);
+		Self::from_raw(val)
+	}
+	
+	pub fn compare_exchange(&self, current: ThreadState, new: ThreadState, success: Ordering, failure: Ordering) {
+		let current = Self::to_raw(current);
+		let new = Self::to_raw(new);
+		let _ = self.0.compare_exchange(current, new, success, failure);
+	}
+}
+
+impl Debug for AtomicThreadState {
+	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+		Debug::fmt(&self.load(Ordering::Relaxed), f)
 	}
 }
 
@@ -226,6 +298,7 @@ pub enum ThreadState {
 	/// The thread has been created, but has not yet started execution,
 	/// and likely has an invalid starting stack
 	Uninit,
+	Dead,
 }
 
 impl ThreadState {

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -197,6 +197,9 @@ pub enum ThreadState {
 	Parked(Arc<ParkGaurd>),
 	/// The thread was unparked but has not been run since
 	JustUnparked(WakeReason),
+	/// The thread has been created, but has not yet started execution,
+	/// and likely has an invalid starting stack
+	Uninit,
 }
 
 impl ThreadState {
@@ -233,6 +236,13 @@ impl ThreadState {
 		match self {
 			Self::JustUnparked(reason) => Some(*reason),
 			_ => None,
+		}
+	}
+
+	pub fn is_uninit(&self) -> bool {
+		match self {
+			Self::Uninit => true,
+			_ => false,
 		}
 	}
 }

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -14,6 +14,7 @@ use super::{parking::ParkGaurd, Thread, ThreadId, ThreadPointer, WakeReason};
 use crate::hal::SaveStateTr;
 use crate::ipc::handle::HandleMap;
 use crate::memory::r#virtual::AddressSpaceInner;
+use crate::threading::subthread_killer::SubthreadKiller;
 
 #[doc(hidden)]
 macro_rules! __tcb_gen_field {
@@ -124,8 +125,9 @@ tcb_views! {
 		state: AtomicThreadState,
 		/// The numerical ID of the thread
 		thread_id: ThreadId,
-		//// The currently open handles
+		/// The currently open handles
 		handles: Arc<HandleMap>,
+		subthread_killer: SubthreadKiller,
 	}
 }
 
@@ -177,6 +179,7 @@ impl ThreadControlBlock {
 			AtomicThreadState::new(ThreadState::Ready),
 			id,
 			Arc::new(HandleMap::new()),
+			SubthreadKiller::new(id),
 		);
 		new_thread.save_state = UnsafeCell::new(SaveState::new(&mut new_thread, startup, main, arg));
 
@@ -194,6 +197,8 @@ impl ThreadControlBlock {
 		).unwrap();
 
 		let id = ThreadId::new();
+		let killer = SubthreadKiller::clone(from.subthread_killer);
+		killer.add_thread(id);
 		let mut new_thread = ThreadControlBlock::new_inner(
 			Arc::clone(from.address_space),
 			Default::default(),
@@ -202,6 +207,7 @@ impl ThreadControlBlock {
 			AtomicThreadState::new(ThreadState::Uninit),
 			id,
 			Arc::clone(from.handles),
+			killer
 		);
 		new_thread.save_state = UnsafeCell::new(SaveState::new(&mut new_thread, startup, uninit_thread_panic, 0));
 

--- a/kernel/src/threading/thread_control_block.rs
+++ b/kernel/src/threading/thread_control_block.rs
@@ -179,10 +179,36 @@ impl ThreadControlBlock {
 
 		(new_thread, id)
 	}
+
+	pub fn clone_uninit_from(from: SharedView, name: Cow<'static, str>, startup: unsafe extern "C" fn()) -> (Self, ThreadId) {
+		extern "C" fn uninit_thread_panic(_: usize) -> ! {
+			panic!("attempted to run an uninit thread")
+		}
+		
+		let new_stack = new_stack(
+			mapping::Config::new(NonZeroUsize::new(32).unwrap()),
+			crate::paging_codes::THREAD_KERNEL_STACK,
+		).unwrap();
+
+		let id = ThreadId::new();
+		let mut new_thread = ThreadControlBlock::new_inner(
+			Arc::clone(from.address_space),
+			Default::default(),
+			name,
+			new_stack,
+			ThreadState::Uninit,
+			id,
+			Arc::clone(from.handles),
+		);
+		new_thread.save_state = UnsafeCell::new(SaveState::new(&mut new_thread, startup, uninit_thread_panic, 0));
+
+		(new_thread, id)
+	}
 }
 
 impl Drop for ThreadControlBlock {
 	fn drop(&mut self) {
+		debug!("dropped TCB for thread {:?}", self.thread_id);
 		assert!(!self.state.get_mut().is_running(), "Cannot drop currently running thread as this would remove the current stack");
 	}
 }

--- a/kernel/src/threading/yielding.rs
+++ b/kernel/src/threading/yielding.rs
@@ -93,10 +93,11 @@ pub fn yield_now() -> Option<WakeReason> {
 	// First we lock the scheduler for the current core, and ask it for the current and new threads
 	// Wrap it in `ManuallyDrop` since we recreate the guard later, as the thread may have migrated
 	// during the context switch
-	let mut scheduler = ManuallyDrop::new(scheduler::local_scheduler().lock());
-	let mut guard = ManuallyDrop::new(percpu_v2!(current_thread).write());
+	let (scheduler, queue) = scheduler::local_scheduler();
+	let mut scheduler = ManuallyDrop::new(scheduler.lock());
 	
-	if let Some(new_thread) = scheduler.get_next_thread() {
+	if let Some(new_thread) = scheduler.get_next_thread(queue) {
+		let mut guard = ManuallyDrop::new(percpu_v2!(current_thread).write());
 		let old_thread = core::mem::replace(&mut **guard, Some(new_thread));
 		let new_thread = guard.as_mut().expect("Just added `new_thread`");
 		
@@ -118,6 +119,7 @@ pub fn yield_now() -> Option<WakeReason> {
 			}
 		}
 	} else {
+		let mut guard = ManuallyDrop::new(percpu_v2!(current_thread).write());
 		// no new thread, so either keep running old thread, or idle
 		let old_thread = guard.take();
 		
@@ -160,7 +162,7 @@ pub fn yield_now() -> Option<WakeReason> {
 }
 
 pub extern "C" fn post_switch_cleanup(mut previous_thread: ThreadPointer) {
-	let mut guard = unsafe { scheduler::local_scheduler().make_guard_unchecked() };
+	let mut guard = unsafe { scheduler::local_scheduler().0.make_guard_unchecked() };
 	let _ = unsafe { percpu_v2!(current_thread).force_unlock_write() };
 	let tcb = previous_thread.tcb_mut();
 	trace!("[b] switch from `{:?}` to current, old blocked in state {:?}", tcb.thread_id, tcb.state);

--- a/kernel/src/threading/yielding.rs
+++ b/kernel/src/threading/yielding.rs
@@ -3,6 +3,7 @@ use core::cell::{LazyCell, UnsafeCell};
 use core::mem::ManuallyDrop;
 use core::ptr;
 use core::ptr::addr_of;
+use core::sync::atomic::Ordering;
 use log::{debug, trace};
 use kernel_api::memory::physical::highmem;
 use kernel_api::sync::{IrqCell, IrqGuard};
@@ -10,7 +11,7 @@ use crate::hal::{ContextSwitchPreserve, self, IpiTarget, TTableTy};
 use crate::hal::paging2::TTable;
 use crate::memory::paging::ktable;
 use crate::memory::r#virtual::AddressSpaceInner;
-use super::{scheduler, WakeReason, ThreadState, scheduler::Scheduler, ThreadPointer, PointerView, Thread, ThreadControlBlock, ThreadId};
+use super::{scheduler, WakeReason, ThreadState, scheduler::Scheduler, ThreadPointer, PointerView, Thread, ThreadControlBlock, ThreadId, ControlEvent};
 
 pub fn create_idle_thread() -> (ThreadId, Thread, UnsafeCell<ThreadPointer>) {
 	extern "C" fn idle_loop(_: usize) -> ! {
@@ -68,10 +69,11 @@ pub fn yield_now() -> Option<WakeReason> {
 
 		#[cfg(feature = "log.scheduler")] trace!("[a] switch from `{:?}` to `{:?}`", from_view.thread_id, to_view.thread_id);
 
-		assert!(to_view.state.is_ready());
-		let reason = to_view.state.wake_reason();
-		*to_view.state = ThreadState::Running;
-		if from_view.state.is_running() { *from_view.state = ThreadState::Ready; }
+		let to_state = to_view.state.load(Ordering::SeqCst);
+		assert!(to_state.is_ready());
+		let reason = to_state.wake_reason();
+		to_view.state.store(ThreadState::Running, Ordering::SeqCst);
+		from_view.state.compare_exchange(ThreadState::Running, ThreadState::Ready, Ordering::SeqCst, Ordering::SeqCst);
 
 		// SAFETY: The AddressSpace is owned by the thread, and thread is always alive while running
 		unsafe {
@@ -94,9 +96,30 @@ pub fn yield_now() -> Option<WakeReason> {
 	// Wrap it in `ManuallyDrop` since we recreate the guard later, as the thread may have migrated
 	// during the context switch
 	let (scheduler, queue) = scheduler::local_scheduler();
-	let mut scheduler = ManuallyDrop::new(scheduler.lock());
+	let mut scheduler = scheduler.lock();
+
+	while let Some(event) = queue.pop() {
+		match event {
+			ControlEvent::Unpark(id, reason) => {
+				match scheduler.unpark(id, reason) {
+					Ok(_) => {},
+					Err(_) => super::parking::do_wake(id, reason),
+				}
+			},
+			ControlEvent::Kill(id) => if Some(id) == percpu_v2!(current_thread).read().as_ref().map(|tcb| *tcb.tcb_ref().thread_id) {
+				super::exit(i8::MIN);
+			} else {
+				match scheduler.kill(id) {
+					Ok(_) => {},
+					Err(_) => super::kill(id),
+				}
+			}
+		}
+	}
 	
-	if let Some(new_thread) = scheduler.get_next_thread(queue) {
+	let mut scheduler = ManuallyDrop::new(scheduler);
+	
+	if let Some(new_thread) = scheduler.get_next_thread() {
 		let mut guard = ManuallyDrop::new(percpu_v2!(current_thread).write());
 		let old_thread = core::mem::replace(&mut **guard, Some(new_thread));
 		let new_thread = guard.as_mut().expect("Just added `new_thread`");
@@ -124,7 +147,7 @@ pub fn yield_now() -> Option<WakeReason> {
 		let old_thread = guard.take();
 		
 		match old_thread {
-			Some(mut old_thread) => if old_thread.tcb_mut().state.is_running() || old_thread.tcb_mut().state.is_ready() {
+			Some(mut old_thread) => if old_thread.tcb_ref().state.load(Ordering::SeqCst).is_running() || old_thread.tcb_ref().state.load(Ordering::Relaxed).is_ready() {
 				debug!("no context switch");
 				
 				// No changes occur to scheduler so just return back to thread, but make sure scheduler gets unlocked
@@ -134,8 +157,8 @@ pub fn yield_now() -> Option<WakeReason> {
 				
 				let old_thread = guard.insert(old_thread);
 				
-				match old_thread.tcb_mut().state {
-					ThreadState::JustUnparked(reason) => Some(*reason),
+				match old_thread.tcb_ref().state.load(Ordering::SeqCst) {
+					ThreadState::JustUnparked(reason) => Some(reason),
 					_ => None,
 				}
 			} else {


### PR DESCRIPTION
To do:
- [x] Make `core.proc.Proc::exit()` actually kill all threads in a process
- [x] Add `core.proc.Thread::yield()` method
    - 6162d504baf618bbcf2687403fb2d154de387f28
    - popcorn-2/core-protocols@6b67784 