### PR TITLE
Add VMO support to the kernel

### DIFF
--- a/kernel/src/ipc/abi_v1.rs
+++ b/kernel/src/ipc/abi_v1.rs
@@ -82,15 +82,17 @@ pub async fn open_async(endpoint: &str, protocols: &[u128]) -> syscall::Result<A
 
 	Ok(match srv.ctor(endpoint, CtorArgs::new(&*protocols)).await? {
 		ReturnHandle::Transfer(handle) => handle,
-		ReturnHandle::New(id, protos) => Handle::new(
+		ReturnHandle::New(id, protos, endpoint) => Handle::new(
 			srv_id,
 			id,
-			&*protos
+			&*protos,
+			endpoint,
 		),
 		ReturnHandle::NewDefault(id) => Handle::new(
 			srv_id,
 			id,
-			protocols
+			protocols,
+			endpoint,
 		)
 	})
 }

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -42,6 +42,17 @@ impl HandleExt for Arc<Handle> {
 	}
 }
 
+#[unsafe(export_name = "__popcorn_ksyscall_blocking")]
+fn kernel_syscall_blocking(
+	this: &Arc<Handle>,
+	protocol: u128,
+	method: u32,
+	args: [usize; 4]
+) -> syscall::Result<u128> {
+	let fut = this.kernel_syscall(protocol, method, args);
+	block_on(fut)
+}
+
 fn handle_syscall_inner(
 	this: &Arc<Handle>,
 	protocol: u128,

--- a/kernel/src/ipc/protocol/mod.rs
+++ b/kernel/src/ipc/protocol/mod.rs
@@ -13,6 +13,19 @@ pub static PROTOCOL_REGISTRY: LazyLock<RwSpinlock<HashMap<u128, meta::Meta>>> = 
 	// fixme: generate pipb files in build.rs, include them here, then run the generic parser
 	let mut map = hashmap_new!();
 
+	// core.mem.Pager
+	map.extend([
+		// get_pages
+		(
+			<dyn generated::core::mem::Pager>::UID | 1 << 96,
+			meta::Meta::Method(
+				[meta::Arg::Primitive, meta::Arg::None, meta::Arg::None, meta::Arg::None],
+				meta::ReturnArg::Primitive,
+				"get_pages@core.mem.Pager",
+			)
+		)
+	]);
+
 	// core.proc.Thread
 	map.extend([
 		// unstable_anon_alloc

--- a/kernel/src/ipc/protocol/mod.rs
+++ b/kernel/src/ipc/protocol/mod.rs
@@ -19,7 +19,7 @@ pub static PROTOCOL_REGISTRY: LazyLock<RwSpinlock<HashMap<u128, meta::Meta>>> = 
 		(
 			<dyn generated::core::mem::Pager>::UID | 1 << 96,
 			meta::Meta::Method(
-				[meta::Arg::Primitive, meta::Arg::None, meta::Arg::None, meta::Arg::None],
+				[meta::Arg::Primitive, meta::Arg::Primitive, meta::Arg::None, meta::Arg::None],
 				meta::ReturnArg::Primitive,
 				"get_pages@core.mem.Pager",
 			)

--- a/kernel/src/ipc/protocol/mod.rs
+++ b/kernel/src/ipc/protocol/mod.rs
@@ -82,6 +82,15 @@ pub static PROTOCOL_REGISTRY: LazyLock<RwSpinlock<HashMap<u128, meta::Meta>>> = 
 				"unstable_mmio_alloc@core.proc.Thread",
 			)
 		),
+		// map_vmo
+		(
+			<dyn generated::core::proc::Thread>::UID | 9 << 96,
+			meta::Meta::Method(
+				[meta::Arg::Handle, meta::Arg::Primitive, meta::Arg::Primitive, meta::Arg::Primitive],
+				meta::ReturnArg::Primitive,
+				"map_vmo@core.proc.Thread",
+			),
+		),
 	].into_iter());
 
 	// core.io.Read

--- a/kernel/src/ipc/serde.rs
+++ b/kernel/src/ipc/serde.rs
@@ -205,7 +205,7 @@ impl Serializer {
 		} else {
 			match result {
 				MethodResult::SelfHandle(id, protos) => {
-					let handle = Handle::new(self.server, id, &protos);
+					let handle = Handle::new(self.server, id, &protos, ""); // fixme: endpoint
 					percpu_v2!(current_thread)
 							.read()
 					        .as_ref()
@@ -215,7 +215,7 @@ impl Serializer {
 							.map(|v| v as u128)
 				}
 				MethodResult::SelfDefaultHandle(id) => {
-					let handle = Handle::new(self.server, id, &self.default_protos);
+					let handle = Handle::new(self.server, id, &self.default_protos, ""); // fixme: endpoint
 					percpu_v2!(current_thread)
 							.read()
 							.as_ref()
@@ -268,8 +268,8 @@ impl From<ReturnHandle> for MethodResult {
 	fn from(value: ReturnHandle) -> Self {
 		match value {
 			ReturnHandle::Transfer(handle) => MethodResult::TransferHandle(handle),
-			ReturnHandle::New(internal_id, protos) => MethodResult::SelfHandle(internal_id, protos),
-			ReturnHandle::NewDefault(internal_id) => MethodResult::SelfDefaultHandle(internal_id),
+			ReturnHandle::New(internal_id, protos, ..) => MethodResult::SelfHandle(internal_id, protos),
+			ReturnHandle::NewDefault(internal_id, ..) => MethodResult::SelfDefaultHandle(internal_id),
 		}
 	}
 }

--- a/kernel/src/ipc/server.rs
+++ b/kernel/src/ipc/server.rs
@@ -22,6 +22,7 @@ pub(super) mod proc;
 pub(super) mod ramdisk;
 mod root;
 mod userspace;
+mod mem;
 
 pub trait Server {
 	type CtorContext: CtorContext;
@@ -57,6 +58,7 @@ pub enum ServerTy {
 	Ramdisk(ramdisk::RamdiskServer),
 	Root(root::RootServer),
 	Userspace(userspace::UserspaceServer),
+	Mem(mem::MemServer),
 }
 
 pub enum ReturnHandle {
@@ -110,6 +112,11 @@ impl ServerTy {
 				args.process_with(s, &mut ctx)?;
 				s.ctor(endpoint, ctx).await
 			}
+			Self::Mem(s) => {
+				let mut ctx = <mem::MemServer as Server>::CtorContext::default();
+				args.process_with(s, &mut ctx)?;
+				s.ctor(endpoint, ctx).await
+			}
 			Self::Userspace(s) => s.ctor(endpoint, args).await,
 		}
 	}
@@ -120,6 +127,7 @@ impl ServerTy {
 			Self::Proc(s) => s.destroy(handle).await,
 			Self::Ramdisk(s) => s.destroy(handle).await,
 			Self::Root(s) => s.destroy(handle).await,
+			Self::Mem(s) => s.destroy(handle).await,
 			Self::Userspace(s) => s.destroy(handle).await,
 		}
 	}
@@ -156,6 +164,9 @@ impl ServerTy {
 				s.dispatch(protocol, method, args[0], args[1], args[2], args[3], args[4])?
 			},
 			ServerTy::Root(s) => {
+				s.dispatch(protocol, method, args[0], args[1], args[2], args[3], args[4])?
+			},
+			ServerTy::Mem(s) => {
 				s.dispatch(protocol, method, args[0], args[1], args[2], args[3], args[4])?
 			},
 			ServerTy::Userspace(_) => unreachable!(),
@@ -198,6 +209,9 @@ impl ServerRegistry {
 		    .expect("Not enough servers inserted yet for overflow");
 
 		list.insert_server(Some(Cow::Borrowed("console")), ServerTy::Console(console::ConsoleServer::new()))
+		    .expect("Not enough servers inserted yet for overflow");
+		
+		list.insert_server(Some(Cow::Borrowed("mem")), ServerTy::Mem(mem::MemServer::new()))
 		    .expect("Not enough servers inserted yet for overflow");
 
 		list

--- a/kernel/src/ipc/server.rs
+++ b/kernel/src/ipc/server.rs
@@ -65,7 +65,7 @@ pub enum ReturnHandle {
 	/// Transfers ownership of a handle to the caller, with support for all the protocols that the original handle had
 	Transfer(Arc<Handle>),
 	/// Creates a handle to a new object, with support for the protocols passed in
-	New(isize, Box<[u128]>),
+	New(isize, Box<[u128]>, alloc::borrow::Cow<'static, str>),
 	/// Creates a handle to a new object, with support for all the protocols that were requested by the caller
 	///
 	/// Only valid to return from a constructor function.

--- a/kernel/src/ipc/server/mem.rs
+++ b/kernel/src/ipc/server/mem.rs
@@ -1,0 +1,76 @@
+use alloc::sync::Arc;
+use core::num::NonZero;
+use slab::Slab;
+use kernel_api::allocator::highmem;
+use kernel_api::memory::{Frames, PAGE_SIZE};
+use kernel_api::sync::{OnceLock, Spinlock};
+use crate::ipc::ctor::{CtorContext, ProtocolVisitor};
+use crate::ipc::{Error, protocol};
+use kernel_api::syscall::handle::Handle;
+use crate::ipc::protocol::DispatchTable;
+use crate::ipc::server::{ReturnHandle, Server};
+use crate::non_zero;
+
+#[derive(Debug)]
+pub struct MemServer {
+	allocations: Spinlock<Slab<Frames<true>>>,
+}
+
+impl MemServer {
+	pub fn new() -> Self { Self { allocations: Spinlock::new(Slab::new()) } }
+}
+
+impl Server for MemServer {
+	type CtorContext = CtorCtx;
+
+	async fn ctor(&self, endpoint: &str, _ctx: CtorCtx) -> Result<ReturnHandle, Error> {
+		let size = endpoint.parse::<NonZero<usize>>()
+				.map_err(|_| Error::InvalidArg)?;
+		if size.get() % PAGE_SIZE != 0 { return Err(Error::InvalidArg); }
+		let size = size.div_ceil(non_zero!(PAGE_SIZE));
+
+		let frames = highmem().allocate(size)?;
+		let key = self.allocations.lock().insert(frames);
+		Ok(ReturnHandle::NewDefault(key as isize))
+	}
+
+	async fn destroy(&self, handle: isize) -> Result<(), Error> {
+		self.allocations.lock().try_remove(handle as usize)
+				.map(|_| ())
+				.ok_or(Error::InvalidHandle)
+	}
+
+	fn dispatch_table(&self) -> &'static DispatchTable {
+		static DISPATCH_TABLE: OnceLock<DispatchTable> = OnceLock::new();
+		DISPATCH_TABLE.get_or_init(|| DispatchTable::new()
+				.add_vtable(<Self as protocol::generated::core::mem::Pager>::__vtable())
+		)
+	}
+}
+
+impl protocol::generated::core::mem::Pager for MemServer {
+	async fn new_from(&self, _: &str, _: Arc<Handle>) -> Result<ReturnHandle, Error> { Err(Error::UnsupportedProtocol) }
+
+	async fn get_pages(&self, handle: isize, offset: usize) -> Result<*const u8, Error> {
+		if offset != 0 { return Err(Error::FutureCompat); }
+
+		let guard = self.allocations.lock();
+		let frames = guard.get(handle as usize).ok_or(Error::InvalidHandle)?;
+		Ok(core::ptr::without_provenance(frames.base().addr))
+	}
+}
+
+
+#[derive(Default)]
+pub struct CtorCtx;
+
+impl CtorContext for CtorCtx {
+	fn visitors(&self) -> &'static ProtocolVisitor<Self> {
+		static VISITORS: OnceLock<ProtocolVisitor<CtorCtx>> = OnceLock::new();
+
+		VISITORS.get_or_init(||
+				ProtocolVisitor::new()
+						.add_visitor::<dyn protocol::generated::core::mem::Pager>(|_, _| Ok(()))
+		)
+	}
+}

--- a/kernel/src/ipc/server/mem.rs
+++ b/kernel/src/ipc/server/mem.rs
@@ -66,12 +66,11 @@ impl Server for MemServer {
 impl protocol::generated::core::mem::Pager for MemServer {
 	async fn new_from(&self, _: &str, _: Arc<Handle>) -> Result<ReturnHandle, Error> { Err(Error::UnsupportedProtocol) }
 
-	async fn get_pages(&self, handle: isize, offset: usize) -> Result<*const u8, Error> {
-		if offset != 0 { return Err(Error::FutureCompat); }
-
+	async fn get_pages(&self, handle: isize, offset: usize, len: usize) -> Result<*const u8, Error> {
 		let guard = self.allocations.lock();
 		let frames = guard.get(handle as usize).ok_or(Error::InvalidHandle)?;
-		Ok(core::ptr::without_provenance(frames.base().addr))
+		if len + offset > frames.count() * PAGE_SIZE { return Err(Error::EoF); }
+		Ok(core::ptr::without_provenance(frames.base().addr + offset))
 	}
 }
 

--- a/kernel/src/ipc/server/mem.rs
+++ b/kernel/src/ipc/server/mem.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 use core::num::NonZero;
 use slab::Slab;
-use kernel_api::allocator::highmem;
+use kernel_api::allocator::{highmem, highmem_zero};
 use kernel_api::memory::{Frames, PAGE_SIZE};
 use kernel_api::sync::{OnceLock, Spinlock};
 use crate::ipc::ctor::{CtorContext, ProtocolVisitor};
@@ -24,17 +24,32 @@ impl Server for MemServer {
 	type CtorContext = CtorCtx;
 
 	async fn ctor(&self, endpoint: &str, _ctx: CtorCtx) -> Result<ReturnHandle, Error> {
-		let size = endpoint.parse::<NonZero<usize>>()
-				.map_err(|_| Error::InvalidArg)?;
-		if size.get() % PAGE_SIZE != 0 { return Err(Error::InvalidArg); }
-		let size = size.div_ceil(non_zero!(PAGE_SIZE));
+		let (flag, size) = {
+			let (flag, size) = match endpoint.split_once('/') {
+				Some((flag, size)) => (flag, size),
+				None => ("", endpoint),
+			};
 
-		let frames = highmem().allocate(size)?;
+			let size = size.parse::<NonZero<usize>>()
+			                   .map_err(|_| Error::InvalidArg)?;
+			if size.get() % PAGE_SIZE != 0 { return Err(Error::InvalidArg); }
+			let size = size.div_ceil(non_zero!(PAGE_SIZE));
+
+			(flag, size)
+		};
+
+		let frames = if flag.contains('z') {
+			highmem_zero().allocate(size)?
+		} else {
+			highmem().allocate(size)?
+		};
+
 		let key = self.allocations.lock().insert(frames);
 		Ok(ReturnHandle::NewDefault(key as isize))
 	}
 
 	async fn destroy(&self, handle: isize) -> Result<(), Error> {
+		info!("destroy mem server allocation {handle}");
 		self.allocations.lock().try_remove(handle as usize)
 				.map(|_| ())
 				.ok_or(Error::InvalidHandle)

--- a/kernel/src/ipc/server/proc.rs
+++ b/kernel/src/ipc/server/proc.rs
@@ -170,6 +170,7 @@ impl protocol::generated::core::proc::Thread for ProcServer {
 			ReturnHandle::New(
 				tid,
 				Box::from([<dyn protocol::generated::core::proc::Thread>::UID]),
+				name.to_owned().into(),
 			)
 		};
 		core::future::ready(res)
@@ -258,10 +259,12 @@ impl protocol::generated::core::proc::Builder for ProcServer {
 		
 		// fixme: hacky
 		let server_id = server::server_registry().name_lookup.get("proc").expect("proc server must exist").clone();
-		let main_thread_handle = meta.handles.push(Handle::new(
+		// fixme: should `thread.main == 3` be an abi guarantee?
+		let main_thread_handle = meta.handles.openat(3, Handle::new(
 			server_id,
 			handle,
 			&[<dyn protocol::generated::core::proc::Thread>::UID],
+			"",
 		))?;
 		handle_nums.insert(Box::from("thread.main"), main_thread_handle);
 
@@ -287,6 +290,7 @@ impl protocol::generated::core::proc::Builder for ProcServer {
 		Ok(ReturnHandle::New(
 			handle,
 			Box::from([<dyn protocol::generated::core::proc::Thread>::UID]),
+			"[thread]".into(),
 		))
 	}
 

--- a/kernel/src/ipc/server/proc.rs
+++ b/kernel/src/ipc/server/proc.rs
@@ -24,6 +24,7 @@ use crate::ipc::protocol::generated::core::io::{Read, Seek};
 use crate::ipc::server::{Either, ReturnHandle, Server};
 use crate::{hal, threading};
 use kernel_api::threading::{ThreadId, ThreadMeta};
+use alloc::borrow::Cow;
 
 /// Manages thread objects, implementing `core.proc.Proc` and `core.proc.Thread`
 ///
@@ -226,16 +227,22 @@ impl protocol::generated::core::proc::Thread for ProcServer {
 				Thread::Running(meta) => meta,
 			};
 
-			let (_, mapping) = Config::new(len, Ty::USER_MMAP)
+			let ret = {
+				let name = String::from(&**vmo.endpoint());
+
+				let (_, mapping) = Config::new(len, Ty::USER_MMAP)
 					.protection(true, false, true)
 					.with_vmo(vmo, offset)
-					.map_in::<Mmap>("".into(), &thread.address_space)?;
+					.map_in::<Mmap>(Cow::Owned(name), &thread.address_space)?;
 
-			let ret = mapping.as_ptr();
+				let ret = mapping.as_ptr();
 
-			debug!("{:?}", thread.address_space);
+				Ok(ret.addr().as_ptr().cast_const())
+			};
 
-			Ok(ret.addr().as_ptr().cast_const())
+			trace!("{:?}", thread.address_space);
+
+			ret
 		}
 	}
 

--- a/kernel/src/ipc/server/proc.rs
+++ b/kernel/src/ipc/server/proc.rs
@@ -92,7 +92,7 @@ fn unsupported_other_thread(handle: isize) -> Result<(), Error> {
 impl protocol::generated::core::proc::Thread for ProcServer {
 	async fn unstable_anon_alloc(&self, handle: isize, size: usize) -> Result<*const u8, Error> {
 		let Some(len) = NonZero::new(size) else { return Ok(core::ptr::null()); };
-		let len = len.div_ceil(NonZero::new(4096).unwrap());
+		let len = len.div_ceil(NonZero::new(PAGE_SIZE).unwrap());
 
 		let guard = self.threads.lock();
 		let thread = match guard.get(handle as usize).ok_or(Error::InvalidHandle)? {
@@ -187,7 +187,7 @@ impl protocol::generated::core::proc::Thread for ProcServer {
 		if !physical_addr.aligned_to(PAGE_SIZE) { return Err(Error::InvalidArg); }
 
 		let Some(len) = NonZero::new(size) else { return Ok(core::ptr::null()); };
-		let len = len.div_ceil(NonZero::new(4096).unwrap());
+		let len = len.div_ceil(NonZero::new(PAGE_SIZE).unwrap());
 
 		let guard = self.threads.lock();
 		let thread = match guard.get(handle as usize).ok_or(Error::InvalidHandle)?  {
@@ -207,6 +207,35 @@ impl protocol::generated::core::proc::Thread for ProcServer {
 		debug!("{:?}", thread.address_space);
 
 		Ok(ret.addr().as_ptr().cast_const())
+	}
+
+	fn map_vmo(&self, handle: isize, vmo: Arc<Handle>, address: *const u8, len: usize, offset: usize) -> impl Future<Output = Result<*const u8, Error>> {
+		let address = address.addr();
+		async move {
+			if len % PAGE_SIZE != 0 { return Err(Error::InvalidArg); }
+			if offset % PAGE_SIZE != 0 { return Err(Error::InvalidArg); }
+			if address != 0 { return Err(Error::FutureCompat); }
+
+			let Some(len) = NonZero::new(len) else { return Ok(ptr::null()); };
+			let len = len.div_ceil(NonZero::new(PAGE_SIZE).unwrap());
+
+			let guard = self.threads.lock();
+			let thread = match guard.get(handle as usize).ok_or(Error::InvalidHandle)? {
+				Thread::Building { meta, .. } => meta,
+				Thread::Running(meta) => meta,
+			};
+
+			let (_, mapping) = Config::new(len, Ty::USER_MMAP)
+					.protection(true, false, true)
+					.with_vmo(vmo, offset)
+					.map_in::<Mmap>("".into(), &thread.address_space)?;
+
+			let ret = mapping.as_ptr();
+
+			debug!("{:?}", thread.address_space);
+
+			Ok(ret.addr().as_ptr().cast_const())
+		}
 	}
 
 	async fn new_from(&self, _: &str, _: Arc<Handle>) -> Result<ReturnHandle, Error> { Err(Error::UnsupportedProtocol) }

--- a/kernel/src/ipc/server/root.rs
+++ b/kernel/src/ipc/server/root.rs
@@ -138,7 +138,7 @@ impl protocol::generated::core::server::Sync for RootServer {
 		
 		debug!("forge handle for server {server:?} with num {handle_num:#x} and protos {protocols:#x?}");
 		
-		let new_handle = Handle::new(server, handle_num, protocols);
+		let new_handle = Handle::new(server, handle_num, protocols, "[forged]");
 
 		Ok(ReturnHandle::Transfer(new_handle))
 	}

--- a/kernel/src/ipc/server/userspace.rs
+++ b/kernel/src/ipc/server/userspace.rs
@@ -228,7 +228,7 @@ impl UserspaceServer {
 			match v {
 				MethodResult::Value(_) => Err(Error::InvalidReturn),
 				MethodResult::TransferHandle(handle) => Ok(ReturnHandle::Transfer(handle)),
-				MethodResult::SelfHandle(id, protos) => Ok(ReturnHandle::New(id, protos)),
+				MethodResult::SelfHandle(id, protos) => Ok(ReturnHandle::New(id, protos, endpoint.to_owned().into())),
 				MethodResult::SelfDefaultHandle(id) => Ok(ReturnHandle::NewDefault(id)),
 			}
 		})

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -939,17 +939,20 @@ fn kmain(handoff_data: HandoffWrapper) -> ! {
 		let thread_handle = Handle::new(
 			ipc::server::server_registry().get_server_at("proc").expect("unable to open `proc`").0,
 			thread.thread_id.get() as isize,
-			&[<dyn ipc::protocol::generated::core::proc::Thread>::UID]
+			&[<dyn ipc::protocol::generated::core::proc::Thread>::UID],
+			"",
 		);
 		let ramdisk_handle = Handle::new(
 			ramdisk_server,
 			1,
-			&[<dyn ipc::protocol::generated::core::io::Read>::UID]
+			&[<dyn ipc::protocol::generated::core::io::Read>::UID],
+			"",
 		);
 		let acpi_handle = Handle::new(
 			ramdisk_server,
 			2,
-			&[<dyn ipc::protocol::generated::core::io::Read>::UID]
+			&[<dyn ipc::protocol::generated::core::io::Read>::UID],
+			"",
 		);
 
 		dbg!(&stdio_handle);

--- a/kernel_api/src/allocator/mod.rs
+++ b/kernel_api/src/allocator/mod.rs
@@ -26,4 +26,11 @@ enum AllocProvider {
 	Pmm,
 	Vmm,
 	Heap,
+	Syscall(crate::syscall::Error),
+}
+
+impl From<crate::syscall::Error> for AllocError {
+	fn from(value: crate::syscall::Error) -> Self {
+		AllocError { provider: AllocProvider::Syscall(value) }
+	}
 }

--- a/kernel_api/src/allocator/pmm.rs
+++ b/kernel_api/src/allocator/pmm.rs
@@ -22,6 +22,38 @@ pub const fn dmamem() -> DynPmm<'static, true> {
 	DynPmm::from(&crate::bridge::memory::GLOBAL_DMA)
 }
 
+/// Returns an allocator which uses the [`highmem`](highmem()) allocator as a backing allocator but zeroes all memory
+#[inline]
+pub const fn highmem_zero() -> DynPmm<'static, true> {
+	struct Zero;
+
+	unsafe impl Pmm<true> for Zero {
+		fn allocate_one_raw(&self) -> Result<RawFrame, AllocError> {
+			let mut frame = highmem().allocate_one()?;
+			frame.write_filled(0);
+			Ok(Frames::into_raw(frame).0.start)
+		}
+
+		fn allocate_raw(&self, count: NonZero<usize>) -> Result<RawFrame, AllocError> {
+			let mut frames = highmem().allocate(count)?;
+			frames.write_filled(0);
+			Ok(Frames::into_raw(frames).0.start)
+		}
+
+		fn allocate_raw_at(&self, at: RawFrame, count: NonZero<usize>) -> Result<RawFrame, AllocError> {
+			let mut frames = highmem().allocate_at(at, count)?;
+			frames.write_filled(0);
+			Ok(Frames::into_raw(frames).0.start)
+		}
+
+		unsafe fn deallocate_raw(&self, base: RawFrame, count: NonZero<usize>) {
+			unsafe { highmem().deallocate_raw(base, count) }
+		}
+	}
+	
+	DynPmm::from(&Zero)
+}
+
 /// A physical memory allocator
 /// 
 /// If the allocator only allocates from conventional RAM, then the

--- a/kernel_api/src/bridge/kernel_abi_v1.rs
+++ b/kernel_api/src/bridge/kernel_abi_v1.rs
@@ -50,11 +50,21 @@ pub mod executor {
 }
 
 pub mod handle {
+	use alloc::sync::Arc;
+	use crate::syscall;
 	use crate::syscall::handle::Handle;
 
 	unsafe extern "Rust" {
 		#[link_name = "__popcorn_handle_drop"]
 		pub safe fn drop(this: &mut Handle);
+
+		#[link_name = "__popcorn_ksyscall_blocking"]
+		pub safe fn kernel_syscall_blocking(
+			this: &Arc<Handle>,
+			protocol: u128,
+			method: u32,
+			args: [usize; 4]
+		) -> syscall::Result<u128>;
 	}
 }
 

--- a/kernel_api/src/mapping/config.rs
+++ b/kernel_api/src/mapping/config.rs
@@ -236,7 +236,7 @@ mod full {
 			Ok(Mapping {
 				raw,
 				address_space: ManuallyDrop::new(address_space),
-				backing: Backing::Contiguous(frames),
+				backing: ManuallyDrop::new(Backing::Contiguous(frames)),
 				caching: self.caching,
 				virtual_start: pages,
 				protection: self.protection,
@@ -269,7 +269,7 @@ mod full {
 			}
 		}
 
-		pub fn with_vmo(self, vmo: Arc<Handle>, ) -> Self {
+		pub fn with_vmo(self, vmo: Arc<Handle>) -> Self {
 			assert!(vmo.has_protocols(&[6]), "vmo handle must support `core.mem.Pager`");
 			todo!()
 		}

--- a/kernel_api/src/mapping/config.rs
+++ b/kernel_api/src/mapping/config.rs
@@ -269,8 +269,9 @@ mod full {
 			}
 		}
 
-		pub fn with_vmo(self, vmo: Arc<Handle>) -> Self {
+		pub fn with_vmo(self, vmo: Arc<Handle>, offset: usize) -> Self {
 			assert!(vmo.has_protocols(&[6]), "vmo handle must support `core.mem.Pager`");
+			assert_eq!(offset % 4096, 0, "vmo offset must be page aligned");
 			todo!()
 		}
 

--- a/kernel_api/src/mapping/config.rs
+++ b/kernel_api/src/mapping/config.rs
@@ -105,11 +105,17 @@ mod full {
 	}
 
 	#[derive(Debug)]
+	enum AllocatorTy {
+		Vmo(Arc<Handle>),
+		Pmm(DynPmm<'static, false>),
+	}
+
+	#[derive(Debug)]
 	pub struct Config {
 		physical_location: Location<RawFrame>,
 		virtual_location: Location<RawPage>,
 		page_count: NonZero<usize>,
-		physical_allocator: DynPmm<'static, false>,
+		physical_allocator: AllocatorTy,
 		protection: Protection,
 		caching: Caching,
 		reason: Ty,
@@ -208,9 +214,29 @@ mod full {
 
 		//#[cfg(not(feature = "use_std"))]
 		fn do_map<R: Mappable, A: address_space::Ty>(self, raw: R, address_space: A) -> Result<Mapping<R, A>, AllocError> {
-			let frames = match self.physical_location {
-				Location::At(frame) => self.physical_allocator.allocate_at(frame, self.page_count)?,
-				Location::Any => self.physical_allocator.allocate(self.page_count)?,
+			let Self {
+				physical_allocator,
+				..
+			} = self;
+
+			let (base, backing) = match (physical_allocator, self.physical_location) {
+				(AllocatorTy::Pmm(allocator), Location::At(frame)) => {
+					let frames = allocator.allocate_at(frame, self.page_count)?;
+					(frames.base(), Backing::Contiguous(frames))
+				},
+				(AllocatorTy::Pmm(allocator), Location::Any) => {
+					let mut frames = allocator.allocate(self.page_count)?;
+					(frames.base(), Backing::Contiguous(frames))
+				},
+				(AllocatorTy::Vmo(vmo), _) => {
+					let base_addr = crate::bridge::handle::kernel_syscall_blocking(
+						&vmo,
+						6,
+						1,
+						[ 0 /* offset */, self.page_count.get() * 4096 /* len */, 0, 0 /* unused args */],
+					)?;
+					(RawFrame::new(base_addr as usize), Backing::Vmo { handle: vmo, frame_count: self.page_count.get() })
+				}
 			};
 
 			let virtual_len = raw.virtual_size(self.page_count.get());
@@ -222,7 +248,7 @@ mod full {
 
 			match address_space.map_contiguous(
 				virtual_valid_start,
-				frames.base(),
+				base,
 				self.page_count.get(),
 				self.reason,
 				self.protection,
@@ -236,7 +262,7 @@ mod full {
 			Ok(Mapping {
 				raw,
 				address_space: ManuallyDrop::new(address_space),
-				backing: ManuallyDrop::new(Backing::Contiguous(frames)),
+				backing: ManuallyDrop::new(backing),
 				caching: self.caching,
 				virtual_start: pages,
 				protection: self.protection,
@@ -248,52 +274,47 @@ mod full {
 				physical_location: Location::Any,
 				virtual_location: Location::Any,
 				page_count,
-				physical_allocator: DynPmm::from(highmem()).into(),
+				physical_allocator: AllocatorTy::Pmm(DynPmm::from(highmem()).into()),
 				protection: Protection::new(),
 				caching: Caching::new(),
 				reason: ty,
 			}
 		}
 
-		pub const fn caching(self, caching: Caching) -> Self {
-			Self {
-				caching,
-				.. self
-			}
+		pub const fn caching(mut self, caching: Caching) -> Self {
+			self.caching = caching;
+			self
 		}
 
-		pub const fn protection(self, writable: bool, executable: bool, user_accessible: bool) -> Self {
-			Self {
-				protection: Protection { writable, executable, user_accessible },
-				.. self
-			}
+		pub const fn protection(mut self, writable: bool, executable: bool, user_accessible: bool) -> Self {
+			self.protection = Protection { writable, executable, user_accessible };
+			self
 		}
 
 		pub fn with_vmo(self, vmo: Arc<Handle>, offset: usize) -> Self {
 			assert!(vmo.has_protocols(&[6]), "vmo handle must support `core.mem.Pager`");
 			assert_eq!(offset % 4096, 0, "vmo offset must be page aligned");
-			todo!()
+			Self {
+				physical_allocator: AllocatorTy::Vmo(vmo),
+				.. self
+			}
 		}
 
 		pub fn with_allocator<const RAM_ONLY: bool>(self, allocator: impl Into<DynPmm<'static, RAM_ONLY>>) -> Self {
 			Self {
-				physical_allocator: allocator.into().into(),
+				physical_allocator: AllocatorTy::Pmm(allocator.into().into()),
 				.. self
 			}
 		}
 
-		pub const fn physical_location(self, at: RawFrame) -> Self {
-			Self {
-				physical_location: Location::At(at),
-				.. self
-			}
+		pub const fn physical_location(mut self, at: RawFrame) -> Self {
+			self.physical_location = Location::At(at);
+			self
 		}
 
-		pub const fn virtual_location(self, at: RawPage) -> Self {
-			Self {
-				virtual_location: Location::At(at),
-				.. self
-			}
+		pub const fn virtual_location(mut self, at: RawPage) -> Self {
+			self.virtual_location = Location::At(at);
+			self
 		}
 	}
 }

--- a/kernel_api/src/mapping/mod.rs
+++ b/kernel_api/src/mapping/mod.rs
@@ -43,7 +43,7 @@ mod full {
 		Discontiguous { pmm: DynPmm<'static, false>, frame_count: usize },
 
 		/// The mapping is backed by a VMO handle
-		Vmo(Arc<Handle>),
+		Vmo { handle: Arc<Handle>, frame_count: usize },
 	}
 
 	impl Backing {
@@ -51,7 +51,7 @@ mod full {
 			match self {
 				Backing::Contiguous(frames) => frames.count(),
 				Backing::Discontiguous { frame_count, .. } => *frame_count,
-				Backing::Vmo(_) => todo!(),
+				Backing::Vmo { frame_count, .. } => *frame_count,
 			}
 		}
 
@@ -63,7 +63,7 @@ mod full {
 			match self {
 				Backing::Contiguous(frames) => frames.pmm(),
 				Backing::Discontiguous { pmm, .. } => pmm,
-				Backing::Vmo(_) => todo!(),
+				Backing::Vmo { .. } => todo!(),
 			}
 		}
 	}
@@ -138,7 +138,7 @@ mod full {
 				match unsafe { ManuallyDrop::take(&mut this.backing) } {
 					Backing::Contiguous(frames) => Some(frames),
 					Backing::Discontiguous { .. } => None,
-					Backing::Vmo(_) => todo!(),
+					Backing::Vmo { .. } => todo!(),
 				},
 				this.virtual_start,
 				this.protection,
@@ -213,7 +213,7 @@ mod full {
 				pmm: *self.backing.pmm(),
 				frame_count: self.backing.frame_len().checked_add(extra_length.get()).unwrap()
 			};
-			self.backing = ManuallyDrop::new(new_backing);
+			self.backing = ManuallyDrop::new(new_backing); // don't drop the old backing since that could deallocate in-use frames
 
 			Ok(())
 		}
@@ -252,8 +252,8 @@ mod full {
 				 |f| {
 					 #[cfg(not(feature = "use_std"))] match &*self.backing {
 						 Backing::Contiguous(frame) => Debug::fmt(frame, f),
-						 Backing::Discontiguous { frame_count, .. } => write!(f, "Discontiguous {{ frame_count: {} }}", frame_count),
-						 Backing::Vmo(vmo) => write!(f, "Vmo({vmo:?})"),
+						 Backing::Discontiguous { frame_count, .. } => write!(f, "Discontiguous {{ frame_count: {frame_count} }}"),
+						 Backing::Vmo { handle, frame_count } => write!(f, "Vmo {{ handle: {handle:?}, frame_count: {frame_count} }}"),
 					 }
 					 #[cfg(feature = "use_std")] Ok(())
 				 }
@@ -274,7 +274,7 @@ mod full {
 				Backing::Discontiguous { pmm, frame_count } => {
 					warn!("ignoring discontiguous page drop");
 				}
-				Backing::Vmo(_) => {}
+				Backing::Vmo { handle, .. } => drop(handle),
 			}
 		}
 	}

--- a/kernel_api/src/mapping/mod.rs
+++ b/kernel_api/src/mapping/mod.rs
@@ -9,17 +9,18 @@ pub use config::*;
 
 #[cfg(feature = "full")]
 mod full {
+	use alloc::sync::Arc;
 	use super::*;
 	use core::fmt::{Debug, Formatter};
 	use crate::{address_space, dbg};
 	use core::mem::ManuallyDrop;
 	use core::num::NonZero;
 	use core::ops::Range;
-	use core::{mem, ptr};
-	use log::{debug, warn};
+	use log::{debug, info, warn};
 	use crate::allocator::{AllocError, DynPmm};
 	use crate::memory::{Frames, RawFrame, RawPage, PAGE_SIZE};
 	use crate::ptr::User;
+	use crate::syscall::handle::Handle;
 
 	#[derive(Debug)]
 	pub enum MapPageError {
@@ -40,6 +41,9 @@ mod full {
 
 		/// The underlying physical memory is discontiguous, but all allocated by the same
 		Discontiguous { pmm: DynPmm<'static, false>, frame_count: usize },
+
+		/// The mapping is backed by a VMO handle
+		Vmo(Arc<Handle>),
 	}
 
 	impl Backing {
@@ -47,6 +51,7 @@ mod full {
 			match self {
 				Backing::Contiguous(frames) => frames.count(),
 				Backing::Discontiguous { frame_count, .. } => *frame_count,
+				Backing::Vmo(_) => todo!(),
 			}
 		}
 
@@ -58,6 +63,7 @@ mod full {
 			match self {
 				Backing::Contiguous(frames) => frames.pmm(),
 				Backing::Discontiguous { pmm, .. } => pmm,
+				Backing::Vmo(_) => todo!(),
 			}
 		}
 	}
@@ -66,13 +72,13 @@ mod full {
 	///
 	/// This will allocate any required memory when created, and register any lazily mapped memory as such.
 	/// It will also manage the page tables to correctly unmap the memory when dropped.
-	pub struct Mapping<R, A> {
+	pub struct Mapping<R: Mappable, A: address_space::Ty> {
 		pub(super) raw: R,
 
 		/// The address space mapped into
 		pub(super) address_space: ManuallyDrop<A>,
 
-		pub(super) backing: Backing,
+		pub(super) backing: ManuallyDrop<Backing>,
 		//#[cfg(feature = "use_std")] pub(super) backing: *mut libc::c_void,
 
 		pub(super) caching: Caching,
@@ -118,7 +124,7 @@ mod full {
 			Self {
 				raw: R::default(),
 				address_space: ManuallyDrop::new(address_space::Kernel {}),
-				backing: Backing::Contiguous(unsafe { Frames::<false>::from_raw_tuple(Frames::into_raw(frames)) }),
+				backing: ManuallyDrop::new(Backing::Contiguous(unsafe { Frames::<false>::from_raw_tuple(Frames::into_raw(frames)) })),
 				virtual_start: base_page,
 				protection,
 				caching,
@@ -127,11 +133,12 @@ mod full {
 
 		//#[cfg(not(feature = "use_std"))]
 		pub fn into_raw_parts(self) -> (Option<Frames<false>>, RawPage, Protection, Caching) {
-			let this = ManuallyDrop::new(self);
+			let mut this = ManuallyDrop::new(self);
 			(
-				match unsafe { ptr::read(&this.backing) } {
+				match unsafe { ManuallyDrop::take(&mut this.backing) } {
 					Backing::Contiguous(frames) => Some(frames),
 					Backing::Discontiguous { .. } => None,
+					Backing::Vmo(_) => todo!(),
 				},
 				this.virtual_start,
 				this.protection,
@@ -206,7 +213,7 @@ mod full {
 				pmm: *self.backing.pmm(),
 				frame_count: self.backing.frame_len().checked_add(extra_length.get()).unwrap()
 			};
-			mem::forget(mem::replace(&mut self.backing, new_backing));
+			self.backing = ManuallyDrop::new(new_backing);
 
 			Ok(())
 		}
@@ -220,9 +227,10 @@ mod full {
 		}
 
 		pub fn physical_start(&self) -> Option<RawFrame> {
-			match &self.backing {
+			match &*self.backing {
 				Backing::Contiguous(frames) => Some(frames.base()),
 				Backing::Discontiguous { .. } => None,
+				Backing::Vmo(_) => None,
 			}
 		}
 
@@ -242,9 +250,10 @@ mod full {
 			 .field_with(
 				 "backing",
 				 |f| {
-					 #[cfg(not(feature = "use_std"))] match self.backing {
-						 Backing::Contiguous(ref frame) => Debug::fmt(frame, f),
+					 #[cfg(not(feature = "use_std"))] match &*self.backing {
+						 Backing::Contiguous(frame) => Debug::fmt(frame, f),
 						 Backing::Discontiguous { frame_count, .. } => write!(f, "Discontiguous {{ frame_count: {} }}", frame_count),
+						 Backing::Vmo(vmo) => write!(f, "Vmo({vmo:?})"),
 					 }
 					 #[cfg(feature = "use_std")] Ok(())
 				 }
@@ -256,9 +265,17 @@ mod full {
 		}
 	}
 
-	impl<R, A> Drop for Mapping<R, A> {
+	impl<R: Mappable, A: address_space::Ty> Drop for Mapping<R, A> {
 		fn drop(&mut self) {
-			warn!("Ignoring drop of mmap({})", core::any::type_name::<R>());
+			info!("drop mmap({})", core::any::type_name::<R>());
+
+			match unsafe { ManuallyDrop::take(&mut self.backing) } {
+				Backing::Contiguous(frames) => drop(frames),
+				Backing::Discontiguous { pmm, frame_count } => {
+					warn!("ignoring discontiguous page drop");
+				}
+				Backing::Vmo(_) => {}
+			}
 		}
 	}
 }

--- a/kernel_api/src/mapping/mod.rs
+++ b/kernel_api/src/mapping/mod.rs
@@ -230,7 +230,14 @@ mod full {
 			match &*self.backing {
 				Backing::Contiguous(frames) => Some(frames.base()),
 				Backing::Discontiguous { .. } => None,
-				Backing::Vmo(_) => None,
+				Backing::Vmo { handle, .. } => Some({
+					RawFrame::new(crate::bridge::handle::kernel_syscall_blocking(
+						handle,
+						6,
+						1,
+						[0 /* offset */, self.page_len() * PAGE_SIZE /* len */, 0, 0 /* unused args */],
+					).ok()? as usize)
+				}),
 			}
 		}
 

--- a/kernel_api/src/syscall/handle.rs
+++ b/kernel_api/src/syscall/handle.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::sync::Arc;
 use core::mem::ManuallyDrop;
 use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
@@ -34,7 +35,7 @@ impl HandleMap {
 	pub fn new() -> Self {
 		let this = HandleMapInner {
 			map: Spinlock::new(HashMap::new()),
-			next_fd: AtomicU32::new(3),
+			next_fd: AtomicU32::new(4),
 		};
 		let arc = Arc::new(this);
 		Self(AtomicPtr::new(Arc::into_raw(arc).cast_mut()))
@@ -83,14 +84,16 @@ impl HandleMap {
 pub struct Handle {
 	#[doc(hidden)]
 	pub __protocols: RwSpinlock<ManuallyDrop<HashMap<u128, (ServerId, isize)>>>,
+	endpoint: Arc<str>,
 }
 
 impl Handle {
-	pub fn new(server_id: ServerId, internal_id: isize, protocols: &[u128]) -> Arc<Handle> {
+	pub fn new(server_id: ServerId, internal_id: isize, protocols: &[u128], endpoint: impl Into<Arc<str>>) -> Arc<Handle> {
 		Arc::new(Handle {
 			__protocols: RwSpinlock::new(ManuallyDrop::new(
 				HashMap::from_iter(protocols.iter().copied().zip(core::iter::repeat((server_id, internal_id))))
 			)),
+			endpoint: endpoint.into(),
 		})
 	}
 
@@ -111,6 +114,10 @@ impl Handle {
 		}
 		guard.extend(other.__protocols.read().iter());
 		Ok(())
+	}
+	
+	pub fn endpoint(&self) -> &Arc<str> {
+		&self.endpoint
 	}
 }
 

--- a/kernel_api/src/syscall/result.rs
+++ b/kernel_api/src/syscall/result.rs
@@ -24,7 +24,7 @@ macro_rules! define_error {
 }
 
 define_error! {
-	#[derive(Debug, Copy, Clone)]
+	#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 	#[repr(u16)]
 	pub enum Error {
 		InvalidPointer = 0,

--- a/kernel_api/src/syscall/result.rs
+++ b/kernel_api/src/syscall/result.rs
@@ -24,7 +24,7 @@ macro_rules! define_error {
 }
 
 define_error! {
-	#[derive(Debug)]
+	#[derive(Debug, Copy, Clone)]
 	#[repr(u16)]
 	pub enum Error {
 		InvalidPointer = 0,
@@ -42,7 +42,7 @@ define_error! {
 		AllocationFailure = 12,
 		InvalidArg = 13,
 		AsyncUnsupported = 14,
-		/* error 15 */
+		FutureCompat = 15,
 		EoF = 16,
 		ProtocolOverlap = 17,
 	}


### PR DESCRIPTION
This replaces the perma-unstable anon_allocate and deallocate syscalls by shifting all userspace memory mapping over to Virtual Memory Objects which are endpoints that can provide a region of backing memory upon request, currently only implemented by the new `mem` server which provides anonymous memory backed VMOs